### PR TITLE
optimize image memory usage

### DIFF
--- a/src/TSCutter.GUI/Utils/ImageUtil.cs
+++ b/src/TSCutter.GUI/Utils/ImageUtil.cs
@@ -1,4 +1,5 @@
-﻿using Avalonia;
+﻿using System.Runtime.InteropServices;
+using Avalonia;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Sdcb.FFmpeg.Raw;
@@ -14,17 +15,38 @@ public static class ImageUtil
         var width = frame.Width;
         var height = frame.Height;
         using VideoFrameConverter sws = new();
-        using Frame dest = Frame.CreateVideo(width, height, AVPixelFormat.Bgra);
+        using Frame dest = Frame.CreateVideo(width, height, AVPixelFormat.Bgr24);
         sws.ConvertFrame(frame, dest);
         
-        var stride = width * 4;
-        return new Bitmap(
-            PixelFormat.Bgra8888,
-            AlphaFormat.Premul,
-            dest.Data[0],
-            new PixelSize(width, height),
-            new Vector(dpi, dpi),
-            stride
-        );
+        var writableBitmap = new WriteableBitmap(
+            new PixelSize(width, height), 
+            new Vector(dpi, dpi), 
+            PixelFormat.Bgra8888, 
+            AlphaFormat.Opaque);
+
+        using var buffer = writableBitmap.Lock();
+        var destData = dest.Data[0]; // dest frame data。
+        var stride = dest.Linesize[0]; // bytes per line。
+
+        for (var y = 0; y < height; y++)
+        {
+            var sourcePtr = destData + y * stride;
+            var destPtr = buffer.Address + y * buffer.RowBytes;
+        
+            for (var x = 0; x < width; x++)
+            {
+                var blue = Marshal.ReadByte(sourcePtr + x * 3);
+                var green = Marshal.ReadByte(sourcePtr + x * 3 + 1);
+                var red = Marshal.ReadByte(sourcePtr + x * 3 + 2);
+
+                // write BGRA data
+                Marshal.WriteByte(destPtr + x * 4, blue);
+                Marshal.WriteByte(destPtr + x * 4 + 1, green);
+                Marshal.WriteByte(destPtr + x * 4 + 2, red);
+                Marshal.WriteByte(destPtr + x * 4 + 3, 255); // set alpha to 255
+            }
+        }
+        
+        return writableBitmap;
     }
 }

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -109,8 +109,21 @@ public partial class MainWindowViewModel : ViewModelBase
     [NotifyPropertyChangedFor(nameof(WindowTitle))]
     private string _videoPath;
 
-    [ObservableProperty]
     private Bitmap? _decodedBitmap;
+    public Bitmap? DecodedBitmap
+    {
+        get => _decodedBitmap;
+        set
+        {
+            if (!EqualityComparer<Bitmap?>.Default.Equals(_decodedBitmap, value))
+            {
+                _decodedBitmap?.Dispose();
+                _decodedBitmap = value;
+                OnPropertyChanged();
+            }
+        }
+    }
+    
     [ObservableProperty]
     private double _imageTranslateX;
     [ObservableProperty]


### PR DESCRIPTION
Use `AVPixelFormat.Bgr24` and `WritableBitmap` to reduce memory usage.