### PR TITLE
Add Raw Cutter — TS stream range cutting tool with dual-thumb RangeSlider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,22 @@
 .DS_Store
+
+# AI / Agent directories
+.codebuddy
+.workbuddy
+.trae
+.codex
+.cursor
+.copilot
+.cline
+.augment
+.windsurf
+.cascade
+.qoder
+.replit
+.gemini
+.roo
+.claude
+.sage
+.composer
+.amazonq
+.qwen

--- a/src/TSCutter.GUI/App.axaml.cs
+++ b/src/TSCutter.GUI/App.axaml.cs
@@ -33,6 +33,7 @@ public partial class App : Application
 
         SplatRegistrations.Register<MainWindowViewModel>();
         SplatRegistrations.Register<OutputWindowViewModel>();
+        SplatRegistrations.Register<RawCutterWindowViewModel>();
         SplatRegistrations.Register<AboutWindowViewModel>();
         SplatRegistrations.Register<JumpTimeViewModel>();
         SplatRegistrations.Register<MediainfoWindowViewModel>();
@@ -103,6 +104,7 @@ public partial class App : Application
 
     public static MainWindowViewModel MainWindow => Locator.Current.GetService<MainWindowViewModel>()!;
     public static OutputWindowViewModel OutputDialog => Locator.Current.GetService<OutputWindowViewModel>()!;
+    public static RawCutterWindowViewModel RawCutterDialog => Locator.Current.GetService<RawCutterWindowViewModel>()!;
     public static JumpTimeViewModel JumpTimeDialog => Locator.Current.GetService<JumpTimeViewModel>()!;
     public static AboutWindowViewModel AboutDialog => Locator.Current.GetService<AboutWindowViewModel>()!;
     public static MediainfoWindowViewModel MediainfoDialog => Locator.Current.GetService<MediainfoWindowViewModel>()!;

--- a/src/TSCutter.GUI/Controls/RangeSlider.cs
+++ b/src/TSCutter.GUI/Controls/RangeSlider.cs
@@ -1,0 +1,237 @@
+using System;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Classic.CommonControls;
+
+namespace TSCutter.GUI.Controls;
+
+/// <summary>
+/// 纯手工双拇指 RangeSlider。Canvas 承载轨道、拇指和绿色高亮条。
+/// 拖动拇指调整起止位置，拖动绿色高亮条整体平移区间（滑动窗口）。
+/// </summary>
+public class RangeSlider : Canvas
+{
+    public static readonly StyledProperty<double> MinimumProperty =
+        AvaloniaProperty.Register<RangeSlider, double>(nameof(Minimum), 0);
+
+    public static readonly StyledProperty<double> MaximumProperty =
+        AvaloniaProperty.Register<RangeSlider, double>(nameof(Maximum), 100);
+
+    public static readonly StyledProperty<double> RangeStartProperty =
+        AvaloniaProperty.Register<RangeSlider, double>(nameof(RangeStart), 0);
+
+    public static readonly StyledProperty<double> RangeEndProperty =
+        AvaloniaProperty.Register<RangeSlider, double>(nameof(RangeEnd), 100);
+
+    public double Minimum { get => GetValue(MinimumProperty); set => SetValue(MinimumProperty, value); }
+    public double Maximum { get => GetValue(MaximumProperty); set => SetValue(MaximumProperty, value); }
+    public double RangeStart { get => GetValue(RangeStartProperty); set => SetValue(RangeStartProperty, value); }
+    public double RangeEnd { get => GetValue(RangeEndProperty); set => SetValue(RangeEndProperty, value); }
+
+    private readonly Border _track;
+    private readonly Border _highlight;
+    private readonly Border _startThumb;
+    private readonly Border _endThumb;
+    private bool _draggingStart;
+    private bool _draggingEnd;
+    private bool _draggingRange;
+    private double _dragRangeStart;
+    private double _dragRangeEnd;
+    private double _dragRangePointerX;
+    private double _trackW;
+    private const double ThumbW = 8;
+    private const double ThumbH = 22;
+    private const double TrackH = 12;
+    private const double ControlH = 32;
+
+    static RangeSlider()
+    {
+        MinimumProperty.Changed.AddClassHandler<RangeSlider>((s, _) => s.UpdateVisuals());
+        MaximumProperty.Changed.AddClassHandler<RangeSlider>((s, _) => s.UpdateVisuals());
+        RangeStartProperty.Changed.AddClassHandler<RangeSlider>((s, _) =>
+        { Dispatcher.UIThread.Post(s.UpdateVisuals, DispatcherPriority.Loaded); });
+        RangeEndProperty.Changed.AddClassHandler<RangeSlider>((s, _) =>
+        { Dispatcher.UIThread.Post(s.UpdateVisuals, DispatcherPriority.Loaded); });
+    }
+
+    public RangeSlider()
+    {
+        Height = ControlH;
+        Cursor = new Cursor(StandardCursorType.SizeWestEast);
+
+        // 轨道背景（Z=0 底层）
+        _track = new Border
+        {
+            Height = TrackH,
+            CornerRadius = new CornerRadius(0),
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            IsHitTestVisible = false,
+            ZIndex = 0,
+        };
+
+        // 高亮条（Z=1 在轨道上方）
+        _highlight = new Border
+        {
+            Height = TrackH,
+            CornerRadius = new CornerRadius(0),
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            IsHitTestVisible = true,
+            Cursor = new Cursor(StandardCursorType.SizeAll),
+            ZIndex = 1,
+        };
+
+        // 起始拇指
+        _startThumb = new Border
+        {
+            Width = ThumbW,
+            Height = ThumbH,
+            CornerRadius = new CornerRadius(0),
+            Cursor = new Cursor(StandardCursorType.SizeWestEast),
+            ZIndex = 2,
+        };
+
+        // 结束拇指
+        _endThumb = new Border
+        {
+            Width = ThumbW,
+            Height = ThumbH,
+            CornerRadius = new CornerRadius(0),
+            Cursor = new Cursor(StandardCursorType.SizeWestEast),
+            ZIndex = 2,
+        };
+
+        _startThumb.PointerPressed += (s, e) => { _draggingStart = true; e.Handled = true; };
+        _startThumb.PointerReleased += (s, e) => _draggingStart = false;
+        _endThumb.PointerPressed += (s, e) => { _draggingEnd = true; e.Handled = true; };
+        _endThumb.PointerReleased += (s, e) => _draggingEnd = false;
+        _highlight.PointerPressed += OnHighlightPressed;
+        _highlight.PointerReleased += (s, e) => _draggingRange = false;
+
+        Children.Add(_track);         // 底层 Z=0
+        Children.Add(_highlight);    // 中层 Z=1
+        Children.Add(_startThumb);   // 顶层 Z=2
+        Children.Add(_endThumb);     // 顶层 Z=2
+
+        // 统一处理鼠标移动：根据拖动状态更新对应拇指
+        PointerMoved += OnPointerMoved;
+        // 鼠标释放兜底
+        PointerReleased += (s, e) => { _draggingStart = false; _draggingEnd = false; _draggingRange = false; };
+
+        Loaded += OnLoaded;
+    }
+
+    private void OnLoaded(object? sender, EventArgs e)
+    {
+        var thumbBg = this.FindResource(SystemColors.ControlColorKey) as IBrush
+                      ?? new SolidColorBrush(Color.FromRgb(0x36, 0x36, 0x36));
+        _startThumb.Background = thumbBg;
+        _endThumb.Background = thumbBg;
+
+        var thumbBorder = this.FindResource(SystemColors.ControlDarkColorKey) as IBrush
+                          ?? new SolidColorBrush(Color.FromRgb(0x2c, 0x2c, 0x2c));
+        _startThumb.BorderBrush = thumbBorder;
+        _startThumb.BorderThickness = new Thickness(1);
+        _endThumb.BorderBrush = thumbBorder;
+        _endThumb.BorderThickness = new Thickness(1);
+
+        _highlight.Background = new SolidColorBrush(Colors.Green);
+
+        var trackColor = this.FindResource("SliderTrackFill") as IBrush
+                         ?? new SolidColorBrush(Color.FromRgb(0x80, 0x80, 0x80));
+        _track.Background = trackColor;
+    }
+
+    private void OnHighlightPressed(object? sender, PointerPressedEventArgs e)
+    {
+        _draggingRange = true;
+        _dragRangeStart = RangeStart;
+        _dragRangeEnd = RangeEnd;
+        _dragRangePointerX = e.GetPosition(this).X;
+        e.Handled = true;
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs e)
+    {
+        if (_trackW <= 0) return;
+        var pos = e.GetPosition(this);
+        var ratio = Math.Clamp((pos.X - ThumbW / 2) / (_trackW - ThumbW), 0, 1);
+        var val = Minimum + ratio * (Maximum - Minimum);
+
+        if (_draggingStart)
+        {
+            if (val > RangeEnd) val = RangeEnd;
+            RangeStart = val;
+        }
+        else if (_draggingEnd)
+        {
+            if (val < RangeStart) val = RangeStart;
+            RangeEnd = val;
+        }
+        else if (_draggingRange)
+        {
+            var effectiveW = _trackW - ThumbW;
+            if (effectiveW <= 0) return;
+            var dx = pos.X - _dragRangePointerX;
+            var dv = dx / effectiveW * (Maximum - Minimum);
+            var newStart = _dragRangeStart + dv;
+            var newEnd = _dragRangeEnd + dv;
+
+            if (newStart < Minimum)
+            {
+                newEnd += Minimum - newStart;
+                newStart = Minimum;
+            }
+            if (newEnd > Maximum)
+            {
+                newStart -= newEnd - Maximum;
+                newEnd = Maximum;
+            }
+
+            newStart = Math.Max(Minimum, newStart);
+            newEnd = Math.Min(Maximum, newEnd);
+
+            RangeStart = newStart;
+            RangeEnd = newEnd;
+        }
+    }
+
+    protected override Size ArrangeOverride(Size finalSize)
+    {
+        var result = base.ArrangeOverride(finalSize);
+
+        _trackW = finalSize.Width;
+        SetLeft(_track, 0);
+        SetTop(_track, (ControlH - TrackH) / 2);
+        _track.Width = _trackW;
+
+        SetTop(_highlight, (ControlH - TrackH) / 2);
+
+        SetTop(_startThumb, (ControlH - ThumbH) / 2);
+        SetTop(_endThumb, (ControlH - ThumbH) / 2);
+
+        UpdateVisuals();
+        return result;
+    }
+
+    private void UpdateVisuals()
+    {
+        if (_trackW <= ThumbW || Maximum <= Minimum) return;
+
+        var range = Maximum - Minimum;
+        var startRatio = Math.Clamp((RangeStart - Minimum) / range, 0, 1);
+        var endRatio = Math.Clamp((RangeEnd - Minimum) / range, 0, 1);
+        var effectiveW = _trackW - ThumbW;
+
+        var startX = startRatio * effectiveW;
+        var endX = endRatio * effectiveW;
+
+        SetLeft(_startThumb, startX);
+        SetLeft(_endThumb, endX);
+
+        SetLeft(_highlight, startX + ThumbW / 2);
+        _highlight.Width = Math.Max(0, endX - startX);
+    }
+}

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -24,6 +24,7 @@
     <x:String x:Key="String.Menu.CloseVideo">_Close Video</x:String>
     <x:String x:Key="String.Menu.Exit">_Exit</x:String>
     <x:String x:Key="String.Menu.Tools">_Tools</x:String>
+    <x:String x:Key="String.Menu.RawCutter">_Raw Cutter...</x:String>
     <x:String x:Key="String.Menu.Settings">_Settings...</x:String>
     <x:String x:Key="String.Menu.View">_View</x:String>
     <x:String x:Key="String.Menu.ZoomIn">Zoom In</x:String>
@@ -92,4 +93,20 @@
     <x:String x:Key="String.UpdatesInfo.NewVersionTitle">New version found</x:String>
     <x:String x:Key="String.UpdatesInfo.NewVersionInfo">Current: {0}, New: {1}</x:String>
     <x:String x:Key="String.UpdatesInfo.NewVersionAlert">Do you want to open the download page?</x:String>
+    <x:String x:Key="String.RawCutter.Title">Raw Cutter</x:String>
+    <x:String x:Key="String.RawCutter.FilePath">File Path:</x:String>
+    <x:String x:Key="String.RawCutter.SyncOffset">Sync Offset: {0} bytes</x:String>
+    <x:String x:Key="String.RawCutter.FileSize">File Size:</x:String>
+    <x:String x:Key="String.RawCutter.TotalPackets">Total Packets:</x:String>
+    <x:String x:Key="String.RawCutter.PacketMode">Packet Mode</x:String>
+    <x:String x:Key="String.RawCutter.OffsetMode">Offset Mode</x:String>
+    <x:String x:Key="String.RawCutter.StartPacket">Start Packet:</x:String>
+    <x:String x:Key="String.RawCutter.EndPacket">End Packet:</x:String>
+    <x:String x:Key="String.RawCutter.StartOffset">Start Offset (bytes):</x:String>
+    <x:String x:Key="String.RawCutter.EndOffset">End Offset (bytes):</x:String>
+    <x:String x:Key="String.RawCutter.Output">Output</x:String>
+    <x:String x:Key="String.RawCutter.NoSyncFound">No valid TS sync header found in the file.</x:String>
+    <x:String x:Key="String.RawCutter.InvalidRange">Invalid range. Please check start and end values.</x:String>
+    <x:String x:Key="String.RawCutter.RangeBytes">Range:</x:String>
+    <x:String x:Key="String.RawCutter.OutputSuccess">Output completed successfully!</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -24,6 +24,7 @@
     <x:String x:Key="String.Menu.CloseVideo">关闭视频</x:String>
     <x:String x:Key="String.Menu.Exit">退出(_E)</x:String>
     <x:String x:Key="String.Menu.Tools">工具(_T)</x:String>
+    <x:String x:Key="String.Menu.RawCutter">原始流截取(_R)...</x:String>
     <x:String x:Key="String.Menu.Settings">设置(_S)...</x:String>
     <x:String x:Key="String.Menu.View">视图(_V)</x:String>
     <x:String x:Key="String.Menu.ZoomIn">放大</x:String>
@@ -92,4 +93,20 @@
     <x:String x:Key="String.UpdatesInfo.NewVersionTitle">发现新版本</x:String>
     <x:String x:Key="String.UpdatesInfo.NewVersionInfo">当前版本: {0}, 新版本: {1}</x:String>
     <x:String x:Key="String.UpdatesInfo.NewVersionAlert">是否打开下载页面？</x:String>
+    <x:String x:Key="String.RawCutter.Title">原始流截取</x:String>
+    <x:String x:Key="String.RawCutter.FilePath">文件路径:</x:String>
+    <x:String x:Key="String.RawCutter.SyncOffset">同步偏移: {0} 字节</x:String>
+    <x:String x:Key="String.RawCutter.FileSize">文件大小:</x:String>
+    <x:String x:Key="String.RawCutter.TotalPackets">总 Packet 数:</x:String>
+    <x:String x:Key="String.RawCutter.PacketMode">Packet 模式</x:String>
+    <x:String x:Key="String.RawCutter.OffsetMode">偏移量模式</x:String>
+    <x:String x:Key="String.RawCutter.StartPacket">起始 Packet:</x:String>
+    <x:String x:Key="String.RawCutter.EndPacket">结束 Packet:</x:String>
+    <x:String x:Key="String.RawCutter.StartOffset">起始偏移 (字节):</x:String>
+    <x:String x:Key="String.RawCutter.EndOffset">结束偏移 (字节):</x:String>
+    <x:String x:Key="String.RawCutter.Output">输出</x:String>
+    <x:String x:Key="String.RawCutter.NoSyncFound">未找到有效的 TS 同步头。</x:String>
+    <x:String x:Key="String.RawCutter.InvalidRange">无效的范围，请检查起始和结束值。</x:String>
+    <x:String x:Key="String.RawCutter.RangeBytes">范围:</x:String>
+    <x:String x:Key="String.RawCutter.OutputSuccess">输出完成！</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -24,6 +24,7 @@
     <x:String x:Key="String.Menu.CloseVideo">關閉影片</x:String>
     <x:String x:Key="String.Menu.Exit">離開(_E)</x:String>
     <x:String x:Key="String.Menu.Tools">工具(_T)</x:String>
+    <x:String x:Key="String.Menu.RawCutter">原始流截取(_R)...</x:String>
     <x:String x:Key="String.Menu.Settings">設定(_S)...</x:String>
     <x:String x:Key="String.Menu.View">檢視(_V)</x:String>
     <x:String x:Key="String.Menu.ZoomIn">放大</x:String>
@@ -92,4 +93,20 @@
     <x:String x:Key="String.UpdatesInfo.NewVersionTitle">發現新版本</x:String>
     <x:String x:Key="String.UpdatesInfo.NewVersionInfo">目前版本: {0}, 新版本: {1}</x:String>
     <x:String x:Key="String.UpdatesInfo.NewVersionAlert">是否開啟下載頁面？</x:String>
+    <x:String x:Key="String.RawCutter.Title">原始流截取</x:String>
+    <x:String x:Key="String.RawCutter.FilePath">檔案路徑:</x:String>
+    <x:String x:Key="String.RawCutter.SyncOffset">同步偏移: {0} 位元組</x:String>
+    <x:String x:Key="String.RawCutter.FileSize">檔案大小:</x:String>
+    <x:String x:Key="String.RawCutter.TotalPackets">總 Packet 數:</x:String>
+    <x:String x:Key="String.RawCutter.PacketMode">Packet 模式</x:String>
+    <x:String x:Key="String.RawCutter.OffsetMode">偏移量模式</x:String>
+    <x:String x:Key="String.RawCutter.StartPacket">起始 Packet:</x:String>
+    <x:String x:Key="String.RawCutter.EndPacket">結束 Packet:</x:String>
+    <x:String x:Key="String.RawCutter.StartOffset">起始偏移 (位元組):</x:String>
+    <x:String x:Key="String.RawCutter.EndOffset">結束偏移 (位元組):</x:String>
+    <x:String x:Key="String.RawCutter.Output">輸出</x:String>
+    <x:String x:Key="String.RawCutter.NoSyncFound">未找到有效的 TS 同步頭。</x:String>
+    <x:String x:Key="String.RawCutter.InvalidRange">無效的範圍，請檢查起始和結束值。</x:String>
+    <x:String x:Key="String.RawCutter.RangeBytes">範圍:</x:String>
+    <x:String x:Key="String.RawCutter.OutputSuccess">輸出完成！</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Utils/TsUtil.cs
+++ b/src/TSCutter.GUI/Utils/TsUtil.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IO;
+
+namespace TSCutter.GUI.Utils;
+
+public static class TsUtil
+{
+    public const int TsPacketSize = 188;
+    public const byte TsSyncByte = 0x47;
+
+    /// <summary>
+    /// Searches within maxSearchBytes range for a valid TS sync header offset.
+    /// Returns -1 if not found.
+    /// Validation: checks that 3 consecutive 188-byte spaced positions all start with 0x47.
+    /// </summary>
+    public static long FindSyncOffset(string filePath, long maxSearchBytes = 5 * 1024 * 1024)
+    {
+        using var fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+        var maxScan = Math.Min(maxSearchBytes, fs.Length);
+
+        for (long i = 0; i < maxScan; i++)
+        {
+            fs.Seek(i, SeekOrigin.Begin);
+            var b = fs.ReadByte();
+            if (b == -1) break;
+
+            if ((byte)b == TsSyncByte && VerifySyncPositions(fs, i))
+                return i;
+        }
+
+        return -1;
+    }
+
+    private static bool VerifySyncPositions(FileStream fs, long offset)
+    {
+        for (int j = 1; j <= 3; j++)
+        {
+            var pos = offset + j * TsPacketSize;
+            if (pos >= fs.Length) return false;
+
+            fs.Seek(pos, SeekOrigin.Begin);
+            var b = fs.ReadByte();
+            if (b == -1 || (byte)b != TsSyncByte)
+                return false;
+        }
+        return true;
+    }
+
+    /// <summary>
+    /// Counts complete TS packets starting from syncOffset.
+    /// </summary>
+    public static long CountPackets(string filePath, long syncOffset)
+    {
+        var fileLength = new FileInfo(filePath).Length;
+        return (fileLength - syncOffset) / TsPacketSize;
+    }
+
+    /// <summary>
+    /// Converts a packet index to byte offset in the file.
+    /// </summary>
+    public static long PacketToOffset(long packetIndex, long syncOffset)
+    {
+        return syncOffset + packetIndex * TsPacketSize;
+    }
+}

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -211,6 +211,37 @@ public partial class MainWindowViewModel : ViewModelBase
         SelectedClip!.StartPosition = 0;
     }
 
+    [RelayCommand]
+    private async Task RawCutterClickAsync()
+    {
+        var settings = new OpenFileDialogSettings()
+        {
+            Title = LocalizationManager.Instance.String_OpenTsFile,
+            Filters = new List<FileFilter>()
+            {
+                new(LocalizationManager.Instance.String_TsFiles, ["ts"]),
+            }
+        };
+        var result = await _dialogService.ShowOpenFilesDialogAsync(this, settings);
+        if (!result.Any()) return;
+
+        var filePath = result[0].LocalPath;
+
+        // 检查同步头
+        var syncOffset = await Task.Run(() => TsUtil.FindSyncOffset(filePath));
+        if (syncOffset < 0)
+        {
+            await ShowMessageAsync(
+                LocalizationManager.Instance.String_RawCutter_NoSyncFound,
+                "TSCutter", MessageBoxIcon.Error);
+            return;
+        }
+
+        var dialogViewModel = _dialogService.CreateViewModel<RawCutterWindowViewModel>();
+        dialogViewModel.Initialize(filePath);
+        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+    }
+
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]
     private async Task SaveVideoClickAsync() => await SaveVideoAsync();
 
@@ -574,7 +605,9 @@ public partial class MainWindowViewModel : ViewModelBase
         if (result is null) return;
         
         var dialogViewModel = _dialogService.CreateViewModel<OutputWindowViewModel>();
-        dialogViewModel.SelectedClip = SelectedClip;
+        dialogViewModel.SourceFilePath = SelectedClip!.InFileInfo.FullName;
+        dialogViewModel.StartPosition = SelectedClip!.StartPosition;
+        dialogViewModel.EndPosition = SelectedClip!.EndPosition;
         dialogViewModel.OutputPath = result!.Path!.LocalPath;
         await _dialogService.ShowDialogAsync(this, dialogViewModel).ConfigureAwait(true);
         if (dialogViewModel.Exception is not null)

--- a/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
+using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using HanumanInstitute.MvvmDialogs;
-using TSCutter.GUI.Models;
 using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.ViewModels;
@@ -25,7 +25,9 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
 
     public string PercentStr => $"{Percent:0.00}%";
     public string SpeedStr => $"{CommonUtil.FormatFileSize(Speed)}/s";
-    public PickedClip? SelectedClip { get; set; }
+    public string? SourceFilePath { get; set; }
+    public long StartPosition { get; set; }
+    public long EndPosition { get; set; }
     public string? OutputPath { get; set; }
     public Exception? Exception { get; private set; }
     
@@ -39,7 +41,7 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
         try
         {
             _lastUpdateTime = DateTime.Now;
-            await CommonUtil.CopyFileAsync(SelectedClip!.InFileInfo, OutputPath!, SelectedClip!.StartPosition, SelectedClip!.EndPosition,
+            await CommonUtil.CopyFileAsync(new FileInfo(SourceFilePath!), OutputPath!, StartPosition, EndPosition,
                 (percent, bytesCopied) =>
                 {
                     Percent = percent;

--- a/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
@@ -1,0 +1,341 @@
+using System;
+using System.ComponentModel;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Classic.CommonControls.Dialogs;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HanumanInstitute.MvvmDialogs;
+using HanumanInstitute.MvvmDialogs.FileSystem;
+using HanumanInstitute.MvvmDialogs.FrameworkDialogs;
+using TSCutter.GUI.Utils;
+
+namespace TSCutter.GUI.ViewModels;
+
+public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewModel
+{
+    [ObservableProperty]
+    public partial bool? DialogResult { get; set; }
+
+    private readonly IDialogService _dialogService;
+    private bool _isOutputting; // 防止输出命令重入
+    private CancellationTokenSource? _statusCts; // 状态消息自动消失计时
+    private bool _syncingSlider; // 防止滑块与输入框循环同步
+
+    public RawCutterWindowViewModel(IDialogService dialogService)
+    {
+        _dialogService = dialogService;
+    }
+
+    [ObservableProperty]
+    private string _filePath = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SyncInfo))]
+    private long _syncOffset;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(PacketInfoStr))]
+    private long _totalPackets;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(FileSizeStr))]
+    private long _fileSize;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsOffsetMode))]
+    private bool _isPacketMode = true;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RangeInfoStr))]
+    private long _startPacket;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RangeInfoStr))]
+    private long _endPacket;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RangeInfoStr), nameof(SliderStart))]
+    private long _startOffset;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RangeInfoStr), nameof(SliderEnd))]
+    private long _endOffset;
+
+    /// <summary>
+    /// 输出状态消息，为空时不显示。设置后 2 秒自动清空。
+    /// </summary>
+    [ObservableProperty]
+    private string _statusMessage = string.Empty;
+
+    public bool IsOffsetMode => !IsPacketMode;
+
+    public string SyncInfo => $"Sync: {SyncOffset:N0} Byte";
+
+    public string FileSizeStr => CommonUtil.FormatFileSize(FileSize);
+
+    public string PacketInfoStr => TotalPackets.ToString("N0");
+
+    public string RangeInfoStr => $"{StartOffset:N0} - {EndOffset:N0} ({CommonUtil.FormatFileSize(Math.Max(0, EndOffset - StartOffset + 1))})";
+
+    /// <summary>
+    /// Packet 模式 NumericUpDown 上限。
+    /// </summary>
+    public double PacketMax => Math.Max(0, TotalPackets - 1);
+
+    /// <summary>
+    /// 偏移模式 NumericUpDown 上限。
+    /// </summary>
+    public double OffsetMax => Math.Max(SyncOffset, FileSize - 1);
+
+    /// <summary>
+    /// 滑块范围最小值（始终为 SyncOffset）。
+    /// </summary>
+    public double SliderMin => SyncOffset;
+
+    /// <summary>
+    /// 滑块范围最大值（始终为 FileSize - 1）。
+    /// </summary>
+    public double SliderMax => Math.Max(0, FileSize - 1);
+
+    /// <summary>
+    /// 起始滑块值，双向同步 StartOffset。
+    /// </summary>
+    public double SliderStart
+    {
+        get => StartOffset;
+        set
+        {
+            if (_syncingSlider) return;
+            var v = (long)Math.Round(value);
+            v = Math.Clamp(v, SyncOffset, Math.Max(SyncOffset, FileSize - 1));
+            if (v > SliderEnd) v = (long)SliderEnd;
+            _syncingSlider = true;
+            StartOffset = v;
+            StartPacket = Math.Max(0, (v - SyncOffset) / TsUtil.TsPacketSize);
+            _syncingSlider = false;
+        }
+    }
+
+    /// <summary>
+    /// 结束滑块值，双向同步 EndOffset。
+    /// </summary>
+    public double SliderEnd
+    {
+        get => EndOffset;
+        set
+        {
+            if (_syncingSlider) return;
+            var v = (long)Math.Round(value);
+            v = Math.Clamp(v, SyncOffset, Math.Max(SyncOffset, FileSize - 1));
+            if (v < SliderStart) v = (long)SliderStart;
+            _syncingSlider = true;
+            EndOffset = v;
+            EndPacket = Math.Min((v - SyncOffset) / TsUtil.TsPacketSize, Math.Max(0, TotalPackets - 1));
+            _syncingSlider = false;
+        }
+    }
+
+    public string StartPacketStr
+    {
+        get => StartPacket.ToString();
+        set
+        {
+            if (long.TryParse(value, out var v) && v >= 0 && v < TotalPackets)
+                StartPacket = v;
+        }
+    }
+
+    public string EndPacketStr
+    {
+        get => EndPacket.ToString();
+        set
+        {
+            if (long.TryParse(value, out var v) && v >= 0 && v < TotalPackets)
+                EndPacket = v;
+        }
+    }
+
+    public string StartOffsetStr
+    {
+        get => StartOffset.ToString();
+        set
+        {
+            if (long.TryParse(value, out var v) && v >= 0 && v < FileSize)
+                StartOffset = v;
+        }
+    }
+
+    public string EndOffsetStr
+    {
+        get => EndOffset.ToString();
+        set
+        {
+            if (long.TryParse(value, out var v) && v >= 0 && v < FileSize)
+                EndOffset = v;
+        }
+    }
+
+    /// <summary>
+    /// Initializes the view model with the given TS file path.
+    /// Must be called before displaying the window.
+    /// </summary>
+    public void Initialize(string filePath)
+    {
+        FilePath = filePath;
+        var fileInfo = new FileInfo(filePath);
+        FileSize = fileInfo.Length;
+
+        SyncOffset = TsUtil.FindSyncOffset(filePath);
+        TotalPackets = TsUtil.CountPackets(filePath, SyncOffset);
+
+        EndPacket = Math.Max(0, TotalPackets - 1);
+        StartOffset = TsUtil.PacketToOffset(StartPacket, SyncOffset);
+        EndOffset = FileSize - 1;
+    }
+
+    partial void OnStartPacketChanged(long value)
+    {
+        if (value < 0 || _syncingSlider) return;
+        _syncingSlider = true;
+        StartOffset = TsUtil.PacketToOffset(value, SyncOffset);
+        _syncingSlider = false;
+    }
+
+    partial void OnEndPacketChanged(long value)
+    {
+        if (value < 0 || _syncingSlider) return;
+        _syncingSlider = true;
+        EndOffset = Math.Min(TsUtil.PacketToOffset(value + 1, SyncOffset) - 1, FileSize - 1);
+        _syncingSlider = false;
+    }
+
+    partial void OnIsPacketModeChanged(bool value)
+    {
+        // 切换模式时强制刷新
+        OnPropertyChanged(nameof(RangeInfoStr));
+        OnPropertyChanged(nameof(SliderStart));
+        OnPropertyChanged(nameof(SliderEnd));
+        OnPropertyChanged(nameof(PacketMax));
+        OnPropertyChanged(nameof(OffsetMax));
+    }
+
+    [RelayCommand]
+    private async Task OutputClickAsync()
+    {
+        // 防止重入
+        if (_isOutputting) return;
+        _isOutputting = true;
+        try
+        {
+            await OutputClickCoreAsync();
+        }
+        finally
+        {
+            _isOutputting = false;
+        }
+    }
+
+    /// <summary>
+    /// 输出核心逻辑。始终以调用时刻的 IsPacketMode 为准决定切割方式。
+    /// </summary>
+    private async Task OutputClickCoreAsync()
+    {
+        long startPos, endPos;
+        string defaultNameSuffix;
+
+        if (IsPacketMode)
+        {
+            if (StartPacket < 0 || EndPacket >= TotalPackets || StartPacket > EndPacket)
+            {
+                await ShowMessageAsync(
+                    LocalizationManager.Instance.String_RawCutter_InvalidRange,
+                    "TSCutter", MessageBoxIcon.Warning);
+                return;
+            }
+            startPos = TsUtil.PacketToOffset(StartPacket, SyncOffset);
+            endPos = Math.Min(TsUtil.PacketToOffset(EndPacket + 1, SyncOffset) - 1, FileSize - 1);
+            defaultNameSuffix = $"{StartPacket}-{EndPacket}";
+        }
+        else
+        {
+            startPos = Math.Max(0, StartOffset);
+            endPos = Math.Min(Math.Max(startPos, EndOffset), FileSize - 1);
+            defaultNameSuffix = $"{startPos}-{endPos}";
+        }
+
+        if (startPos >= endPos || endPos >= FileSize)
+        {
+            await ShowMessageAsync(
+                LocalizationManager.Instance.String_RawCutter_InvalidRange,
+                "TSCutter", MessageBoxIcon.Warning);
+            return;
+        }
+
+        var defaultName = Path.GetFileNameWithoutExtension(FilePath) + $"_{defaultNameSuffix}.ts";
+        var settings = new SaveFileDialogSettings
+        {
+            Title = LocalizationManager.Instance.String_RawCutter_Title,
+            SuggestedStartLocation = new DesktopDialogStorageFolder(Path.GetDirectoryName(FilePath)!),
+            SuggestedFileName = defaultName,
+            Filters = [new(LocalizationManager.Instance.String_TsFiles, ["ts"])],
+            DefaultExtension = "ts"
+        };
+
+        var result = await _dialogService.ShowSaveFileDialogAsync(this, settings);
+        if (result is null) return;
+
+        var outputVm = _dialogService.CreateViewModel<OutputWindowViewModel>();
+        outputVm.SourceFilePath = FilePath;
+        outputVm.StartPosition = startPos;
+        outputVm.EndPosition = endPos;
+        outputVm.OutputPath = result.Path!.LocalPath;
+        await _dialogService.ShowDialogAsync(this, outputVm);
+
+        // 仅当正常完成时在窗口内临时显示成功提示
+        if (outputVm.DialogResult == true && outputVm.Exception == null)
+        {
+            ShowStatusMessage(LocalizationManager.Instance.String_RawCutter_OutputSuccess + " " + outputVm.OutputPath);
+        }
+        else if (outputVm.Exception != null)
+        {
+            ShowStatusMessage(LocalizationManager.Instance.String_Error + ": " + outputVm.Exception.Message);
+        }
+    }
+
+    public void OnClosing(CancelEventArgs e)
+    {
+        _statusCts?.Cancel();
+    }
+
+    public event Action? RequestClose;
+
+    /// <summary>
+    /// 在窗口底部临时显示状态消息，2 秒后自动消失。
+    /// </summary>
+    private async void ShowStatusMessage(string message)
+    {
+        _statusCts?.Cancel();
+        _statusCts = new CancellationTokenSource();
+        var token = _statusCts.Token;
+
+        StatusMessage = message;
+        try
+        {
+            await Task.Delay(2000, token);
+            StatusMessage = string.Empty;
+        }
+        catch (TaskCanceledException) { }
+    }
+
+    private async Task ShowMessageAsync(string message, string title, MessageBoxIcon icon)
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopApp)
+        {
+            await MessageBox.ShowDialog(desktopApp.MainWindow!, message, title, MessageBoxButtons.Ok, icon);
+        }
+    }
+}

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -108,6 +108,9 @@
                                   Command="{Binding ExitApplicationCommand}"/>
                     </MenuItem>
                     <MenuItem Header="{DynamicResource String.Menu.Tools}">
+                        <MenuItem Header="{DynamicResource String.Menu.RawCutter}"
+                                  Command="{Binding RawCutterClickCommand}" />
+                        <Separator />
                         <MenuItem Header="{DynamicResource String.Menu.Settings}"
                                   Command="{Binding SettingsClickCommand}" />
                     </MenuItem>

--- a/src/TSCutter.GUI/Views/RawCutterWindow.axaml
+++ b/src/TSCutter.GUI/Views/RawCutterWindow.axaml
@@ -1,0 +1,156 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:TSCutter.GUI"
+        xmlns:viewModels="clr-namespace:TSCutter.GUI.ViewModels"
+        xmlns:controls="clr-namespace:TSCutter.GUI.Controls"
+        mc:Ignorable="d"
+        MinWidth="480" MinHeight="360"
+        Width="520" Height="390"
+        x:Class="TSCutter.GUI.Views.RawCutterWindow"
+        d:DataContext="{x:Static local:App.RawCutterDialog}"
+        CanMinimize="False"
+        CanMaximize="False"
+        WindowStartupLocation="CenterOwner"
+        x:DataType="viewModels:RawCutterWindowViewModel"
+        Title="{DynamicResource String.RawCutter.Title}">
+
+    <Window.Styles>
+        <Style Selector="TextBlock.Label">
+            <Setter Property="VerticalAlignment" Value="Center" />
+        </Style>
+        <Style Selector="TextBox.ReadOnlyPath">
+            <Setter Property="Background" Value="{DynamicResource SystemControlBackgroundBaseLowBrush}" />
+            <Setter Property="IsReadOnly" Value="True" />
+        </Style>
+        <Style Selector="NumericUpDown">
+            <Setter Property="Height" Value="28" />
+        </Style>
+    </Window.Styles>
+
+    <Border BorderThickness="2" Padding="10">
+        <Grid RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto,Auto,*,Auto" ColumnDefinitions="*">
+            <!-- 文件路径 -->
+            <StackPanel Grid.Row="0" Orientation="Vertical" Spacing="2" Margin="0,0,0,8">
+                <TextBlock Text="{DynamicResource String.RawCutter.FilePath}" Classes="Label" />
+                <TextBox Text="{Binding FilePath}" Classes="ReadOnlyPath" />
+            </StackPanel>
+
+            <!-- 同步头偏移信息 -->
+            <TextBlock Grid.Row="1"
+                       Text="{Binding SyncInfo}"
+                       Margin="0,0,0,6" />
+
+            <!-- 文件信息 -->
+            <StackPanel Grid.Row="2" Orientation="Horizontal" Spacing="20" Margin="0,0,0,8">
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <TextBlock Text="{DynamicResource String.RawCutter.FileSize}" Classes="Label" />
+                    <TextBlock Text="{Binding FileSizeStr}" FontWeight="Bold" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="4">
+                    <TextBlock Text="{DynamicResource String.RawCutter.TotalPackets}" Classes="Label" />
+                    <TextBlock Text="{Binding PacketInfoStr}" FontWeight="Bold" />
+                </StackPanel>
+            </StackPanel>
+
+            <!-- 模式切换 RadioButton -->
+            <StackPanel Grid.Row="3" Orientation="Horizontal" Spacing="16" Margin="0,0,0,8">
+                <RadioButton IsChecked="{Binding IsPacketMode}"
+                             GroupName="CutterMode"
+                             Content="{DynamicResource String.RawCutter.PacketMode}" />
+                <RadioButton IsChecked="{Binding IsOffsetMode}"
+                             GroupName="CutterMode"
+                             Content="{DynamicResource String.RawCutter.OffsetMode}" />
+            </StackPanel>
+
+            <!-- 单轨双拇指滑块 -->
+            <controls:RangeSlider Grid.Row="4"
+                                  Margin="0,4"
+                                  HorizontalAlignment="Stretch"
+                                  VerticalAlignment="Center"
+                                  Minimum="{Binding SliderMin}"
+                                  Maximum="{Binding SliderMax}"
+                                  RangeStart="{Binding SliderStart, Mode=TwoWay}"
+                                  RangeEnd="{Binding SliderEnd, Mode=TwoWay}">
+                <controls:RangeSlider.Resources>
+                    <ResourceDictionary>
+                        <ResourceDictionary.MergedDictionaries>
+                            <MergeResourceInclude
+                                Source="avares://TSCutterGUI/Controls/CustomSliderResources.axaml" />
+                        </ResourceDictionary.MergedDictionaries>
+                    </ResourceDictionary>
+                </controls:RangeSlider.Resources>
+            </controls:RangeSlider>
+
+            <!-- 输入区域 -->
+            <Grid Grid.Row="5" ColumnDefinitions="*, *" RowDefinitions="Auto,Auto" Margin="0,10,0,8">
+                <!-- Packet 模式 -->
+                <StackPanel Grid.Column="0" Margin="0,0,8,0"
+                            IsVisible="{Binding IsPacketMode}"
+                            Orientation="Vertical" Spacing="2">
+                    <TextBlock Text="{DynamicResource String.RawCutter.StartPacket}" Classes="Label" />
+                    <NumericUpDown Value="{Binding StartPacket, Mode=TwoWay}"
+                                   Minimum="0"
+                                   Maximum="{Binding PacketMax}"
+                                   Increment="1"
+                                   ParsingNumberStyle="Integer" />
+                </StackPanel>
+                <StackPanel Grid.Column="1"
+                            IsVisible="{Binding IsPacketMode}"
+                            Orientation="Vertical" Spacing="2">
+                    <TextBlock Text="{DynamicResource String.RawCutter.EndPacket}" Classes="Label" />
+                    <NumericUpDown Value="{Binding EndPacket, Mode=TwoWay}"
+                                   Minimum="0"
+                                   Maximum="{Binding PacketMax}"
+                                   Increment="1"
+                                   ParsingNumberStyle="Integer" />
+                </StackPanel>
+
+                <!-- 偏移量模式 -->
+                <StackPanel Grid.Column="0" Margin="0,0,8,0"
+                            IsVisible="{Binding IsOffsetMode}"
+                            Orientation="Vertical" Spacing="2">
+                    <TextBlock Text="{DynamicResource String.RawCutter.StartOffset}" Classes="Label" />
+                    <NumericUpDown Value="{Binding StartOffset, Mode=TwoWay}"
+                                   Minimum="{Binding SyncOffset}"
+                                   Maximum="{Binding OffsetMax}"
+                                   Increment="188"
+                                   ParsingNumberStyle="Integer" />
+                </StackPanel>
+                <StackPanel Grid.Column="1"
+                            IsVisible="{Binding IsOffsetMode}"
+                            Orientation="Vertical" Spacing="2">
+                    <TextBlock Text="{DynamicResource String.RawCutter.EndOffset}" Classes="Label" />
+                    <NumericUpDown Value="{Binding EndOffset, Mode=TwoWay}"
+                                   Minimum="{Binding SyncOffset}"
+                                   Maximum="{Binding OffsetMax}"
+                                   Increment="188"
+                                   ParsingNumberStyle="Integer" />
+                </StackPanel>
+            </Grid>
+
+            <!-- 状态消息提示 -->
+            <TextBlock Grid.Row="6"
+                       Text="{Binding StatusMessage}"
+                       IsVisible="{Binding StatusMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}"
+                       TextWrapping="Wrap"
+                       Margin="0,4,0,4"
+                       VerticalAlignment="Top" />
+
+            <!-- 底部按钮 -->
+            <Grid Grid.Row="8" ColumnDefinitions="Auto,*">
+                <!-- 计算结果提示 -->
+                <StackPanel Grid.Column="0" Orientation="Horizontal" Spacing="4" VerticalAlignment="Center">
+                    <TextBlock Text="{DynamicResource String.RawCutter.RangeBytes}" Classes="Label" />
+                    <TextBlock Text="{Binding RangeInfoStr}" FontWeight="Bold" />
+                </StackPanel>
+                <Button Grid.Column="1"
+                        Content="{DynamicResource String.RawCutter.Output}"
+                        Width="100"
+                        HorizontalAlignment="Right"
+                        Command="{Binding OutputClickCommand}" />
+            </Grid>
+        </Grid>
+    </Border>
+</Window>

--- a/src/TSCutter.GUI/Views/RawCutterWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/RawCutterWindow.axaml.cs
@@ -1,0 +1,22 @@
+using System;
+using Classic.Avalonia.Theme;
+using TSCutter.GUI.ViewModels;
+
+namespace TSCutter.GUI.Views;
+
+public partial class RawCutterWindow : ClassicWindow
+{
+    public RawCutterWindow()
+    {
+        InitializeComponent();
+        Loaded += OnInitialized;
+    }
+
+    private void OnInitialized(object? sender, EventArgs e)
+    {
+        if (DataContext is RawCutterWindowViewModel vm)
+        {
+            vm.RequestClose += Close;
+        }
+    }
+}


### PR DESCRIPTION
## Description (English)
### Summary
This PR introduces the Raw Cutter feature, a tool for extracting byte ranges from raw TS (Transport Stream) files by packet index or byte offset. It also adds a reusable RangeSlider control and TS sync header detection utilities.

### New Features
- Raw Cutter Window ( RawCutterWindow )
  
  - Open any .ts file and automatically detect the TS sync byte offset
  - Two cutting modes: Packet mode (by packet index) and Offset mode (by absolute byte position)
  - Mode switching via radio buttons with independent numeric inputs
  - Real-time range info display (byte range + size)
  - Output via the existing output pipeline with temporary success/error status messages
  - Status messages appear below inputs without causing UI layout jitter (buffered by a * spacer row)
  - Window allows manual resize, but no minimize/maximize buttons
  - Full localization in en-US, zh-CN ("原始流截取"), zh-TW ("原始流截取")
- RangeSlider Control ( RangeSlider )
  
  - Custom Canvas-based dual-thumb slider, no external dependencies
  - Styled with Classic Windows theme system colors ( SystemColors.ControlColorKey / ControlDarkColorKey )
  - Three interaction modes:
    - Drag left thumb — adjust RangeStart
    - Drag right thumb — adjust RangeEnd
    - Drag green highlight bar — translate the entire range as a sliding window (preserving width, with boundary clamping)
  - All size constants centralized, thicker thumb/track for easier grabbing (ThumbW=8, TrackH=12, ThumbH=22, ControlH=32)
- TsUtil ( TsUtil )
  
  - FindSyncOffset() — scans file for valid TS sync byte (0x47) with 3-consecutive-packet verification
  - CountPackets() / PacketToOffset() — packet counting and position conversion helpers
### Other Changes
- OutputWindowViewModel refactored: replaced SelectedClip dependency with SourceFilePath , StartPosition , EndPosition for flexible reuse by Raw Cutter
- Main menu added "Raw Cutter" entry under Tools, with Ctrl+R access key (English) / _R (Chinese)
- .gitignore expanded with common AI/agent directory patterns ( .cursor , .copilot , .cline , .windsurf , etc.)

---

### 概述
本次 PR 新增 原始流截取（Raw Cutter） 功能——可按 Packet 序号或字节偏移从原始 TS 文件中截取片段输出。同时提供了一个可复用的 RangeSlider 双拇指滑块控件，以及 TS 同步头检测工具类。

### 新增功能
- 原始流截取窗口
  
  - 打开 .ts 文件自动检测 TS 同步字节偏移
  - 两种切割模式： Packet 模式 （按包序号）/ 偏移量模式 （按绝对字节位置）
  - RadioButton 切换模式，各自独立 NumericUpDown 输入
  - 实时显示范围信息（字节区间 + 大小）
  - 复用现有输出流程，输出完成后临时显示成功/失败提示
  - 提示信息紧贴输入框下方显示，底部按钮始终不动（通过 * 缓冲行消除抖动）
  - 窗口允许手动拖拽 resize，但无最小化/最大化按钮
  - 完整三语本地化（en-US / zh-CN / zh-TW）
- RangeSlider 自定义控件
  
  - 纯 Canvas 手工绘制双拇指滑块，无外部依赖
  - 配色对齐 Classic Windows 主题系统色（ ControlColorKey / ControlDarkColorKey ）
  - 三种拖拽操作：
    - 拖左拇指 — 调整起始位置
    - 拖右拇指 — 调整结束位置
    - 拖绿色高亮区域 — 滑动窗口式整体平移区间，不改变宽度，触碰边界自动刹车
  - 尺寸统一加大（拇指 8×22，轨道 12px 高），绿色区域拖起来更顺手
- TsUtil 工具类
  
  - FindSyncOffset() — 扫描文件找 TS 同步字节 0x47，连续 3 包验证
  - CountPackets() / PacketToOffset() — Packet 数计算与位置换算
### 其他改动
- OutputWindowViewModel 重构：原先依赖 SelectedClip 改为 SourceFilePath + StartPosition + EndPosition ，方便 Raw Cutter 复用
- 主菜单 Tools 下新增"原始流截取"入口，英文 Ctrl+R / 中文 (_R) 快捷键
- .gitignore 扩充主流 AI/Agent 工具目录