### PR TITLE
Support copy image to clipboard

### DIFF
--- a/src/TSCutter.GUI/App.axaml.cs
+++ b/src/TSCutter.GUI/App.axaml.cs
@@ -9,6 +9,7 @@ using Classic.CommonControls.Dialogs;
 using HanumanInstitute.MvvmDialogs;
 using HanumanInstitute.MvvmDialogs.Avalonia;
 using Splat;
+using TSCutter.GUI.Converters;
 using TSCutter.GUI.Models;
 using TSCutter.GUI.Services;
 using TSCutter.GUI.Utils;
@@ -39,6 +40,7 @@ public partial class App : Application
         SplatRegistrations.Register<MediainfoWindowViewModel>();
         SplatRegistrations.Register<SettingsWindowViewModel>();
         SplatRegistrations.Register<UpdatesInfoWindowViewModel>();
+        SplatRegistrations.Register<CaptureFrameViewModel>();
         // --- 注册单例服务 ---
         var localizationService = new LocalizationService();
         SplatRegistrations.RegisterConstant<ILocalizationService>(localizationService);
@@ -110,6 +112,8 @@ public partial class App : Application
     public static MediainfoWindowViewModel MediainfoDialog => Locator.Current.GetService<MediainfoWindowViewModel>()!;
     public static SettingsWindowViewModel SettingsDialog => Locator.Current.GetService<SettingsWindowViewModel>()!;
     public static UpdatesInfoWindowViewModel UpdatesInfoDialog => Locator.Current.GetService<UpdatesInfoWindowViewModel>()!;
+    public static CaptureFrameViewModel CaptureFrameDialog => Locator.Current.GetService<CaptureFrameViewModel>()!;
+    public static InverseBoolConverter InverseBoolConverter => InverseBoolConverter.Instance;
     public static IDialogService DialogService => Locator.Current.GetService<IDialogService>()!;
     public static ILocalizationService LocalizationService => Locator.Current.GetService<ILocalizationService>()!;
 }

--- a/src/TSCutter.GUI/Converters/InverseBoolConverter.cs
+++ b/src/TSCutter.GUI/Converters/InverseBoolConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace TSCutter.GUI.Converters;
+
+public class InverseBoolConverter : IValueConverter
+{
+    public static readonly InverseBoolConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+            return !b;
+        return value;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is bool b)
+            return !b;
+        return value;
+    }
+}

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -8,6 +8,7 @@
     <x:String x:Key="String.WrongFormat">Wrong Format</x:String>
     <x:String x:Key="String.SaveFrame">Save a frame</x:String>
     <x:String x:Key="String.PngImages">PNG Images</x:String>
+    <x:String x:Key="String.JpgImages">JPG Images</x:String>
     <x:String x:Key="String.TsFiles">MPEG2-TS Videos</x:String>
     <x:String x:Key="String.AllFiles">All Files</x:String>
     <x:String x:Key="String.Error">Error</x:String>
@@ -109,4 +110,9 @@
     <x:String x:Key="String.RawCutter.InvalidRange">Invalid range. Please check start and end values.</x:String>
     <x:String x:Key="String.RawCutter.RangeBytes">Range:</x:String>
     <x:String x:Key="String.RawCutter.OutputSuccess">Output completed successfully!</x:String>
+    <x:String x:Key="String.CaptureFrame.Title">Capture Frame</x:String>
+    <x:String x:Key="String.CaptureFrame.Action">Action</x:String>
+    <x:String x:Key="String.CaptureFrame.CopyToClipboard">Copy to Clipboard</x:String>
+    <x:String x:Key="String.CaptureFrame.SaveToFile">Save to File</x:String>
+    <x:String x:Key="String.CaptureFrame.Format">Format</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -8,6 +8,7 @@
     <x:String x:Key="String.WrongFormat">格式错误</x:String>
     <x:String x:Key="String.SaveFrame">保存帧</x:String>
     <x:String x:Key="String.PngImages">PNG 图片</x:String>
+    <x:String x:Key="String.JpgImages">JPG 图片</x:String>
     <x:String x:Key="String.TsFiles">MPEG2-TS 视频</x:String>
     <x:String x:Key="String.AllFiles">所有文件</x:String>
     <x:String x:Key="String.Error">错误</x:String>
@@ -109,4 +110,9 @@
     <x:String x:Key="String.RawCutter.InvalidRange">无效的范围，请检查起始和结束值。</x:String>
     <x:String x:Key="String.RawCutter.RangeBytes">范围:</x:String>
     <x:String x:Key="String.RawCutter.OutputSuccess">输出完成！</x:String>
+    <x:String x:Key="String.CaptureFrame.Title">截图</x:String>
+    <x:String x:Key="String.CaptureFrame.Action">操作</x:String>
+    <x:String x:Key="String.CaptureFrame.CopyToClipboard">复制到剪贴板</x:String>
+    <x:String x:Key="String.CaptureFrame.SaveToFile">保存到文件</x:String>
+    <x:String x:Key="String.CaptureFrame.Format">格式</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -8,6 +8,7 @@
     <x:String x:Key="String.WrongFormat">格式錯誤</x:String>
     <x:String x:Key="String.SaveFrame">儲存影格</x:String>
     <x:String x:Key="String.PngImages">PNG 圖片</x:String>
+    <x:String x:Key="String.JpgImages">JPG 圖片</x:String>
     <x:String x:Key="String.TsFiles">MPEG2-TS 影片</x:String>
     <x:String x:Key="String.AllFiles">所有檔案</x:String>
     <x:String x:Key="String.Error">錯誤</x:String>
@@ -109,4 +110,9 @@
     <x:String x:Key="String.RawCutter.InvalidRange">無效的範圍，請檢查起始和結束值。</x:String>
     <x:String x:Key="String.RawCutter.RangeBytes">範圍:</x:String>
     <x:String x:Key="String.RawCutter.OutputSuccess">輸出完成！</x:String>
+    <x:String x:Key="String.CaptureFrame.Title">截圖</x:String>
+    <x:String x:Key="String.CaptureFrame.Action">操作</x:String>
+    <x:String x:Key="String.CaptureFrame.CopyToClipboard">複製到剪貼簿</x:String>
+    <x:String x:Key="String.CaptureFrame.SaveToFile">儲存到檔案</x:String>
+    <x:String x:Key="String.CaptureFrame.Format">格式</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Utils/ImageUtil.cs
+++ b/src/TSCutter.GUI/Utils/ImageUtil.cs
@@ -1,13 +1,17 @@
-﻿using System;
+using System;
 using System.Globalization;
+using System.IO;
 using System.Runtime.InteropServices;
 using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Platform;
 using Sdcb.FFmpeg.Raw;
 using Sdcb.FFmpeg.Swscales;
 using Sdcb.FFmpeg.Utils;
+using SkiaSharp;
 
 namespace TSCutter.GUI.Utils;
 
@@ -81,5 +85,40 @@ public static class ImageUtil
         ctx.DrawText(formattedText, textPosition);
 
         return bitmap;
+    }
+
+    public static void SaveAsJpeg(Bitmap bitmap, Stream stream, int quality = 90)
+    {
+        using var pngStream = new MemoryStream();
+        bitmap.Save(pngStream);
+        pngStream.Position = 0;
+        using var skBitmap = SKBitmap.Decode(pngStream);
+        using var skImage = SKImage.FromBitmap(skBitmap);
+        using var data = skImage.Encode(SKEncodedImageFormat.Jpeg, quality);
+        data.SaveTo(stream);
+    }
+
+    public static void CopyBitmapToClipboard(Bitmap bitmap, bool isPng)
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopApp
+            && desktopApp.MainWindow?.Clipboard is { } clipboard)
+        {
+            var dt = new DataTransfer();
+            if (isPng)
+            {
+                var bitmapItem = new DataTransferItem();
+                bitmapItem.SetBitmap(bitmap);
+                dt.Add(bitmapItem);
+            }
+            else
+            {
+                using var jpgStream = new MemoryStream();
+                SaveAsJpeg(bitmap, jpgStream);
+                var jpgItem = new DataTransferItem();
+                jpgItem.Set(DataFormat.CreateBytesPlatformFormat("public.jpeg"), jpgStream.ToArray());
+                dt.Add(jpgItem);
+            }
+            _ = clipboard.SetDataAsync(dt);
+        }
     }
 }

--- a/src/TSCutter.GUI/ViewModels/CaptureFrameViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/CaptureFrameViewModel.cs
@@ -1,0 +1,32 @@
+using System;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using HanumanInstitute.MvvmDialogs;
+
+namespace TSCutter.GUI.ViewModels;
+
+public partial class CaptureFrameViewModel : ViewModelBase, IModalDialogViewModel
+{
+    [ObservableProperty]
+    public partial bool IsSaveToFile { get; set; } = true;
+
+    [ObservableProperty]
+    public partial bool IsPngFormat { get; set; } = true;
+
+    [RelayCommand]
+    private void Cancel()
+    {
+        RequestClose?.Invoke();
+    }
+
+    [RelayCommand]
+    private void Confirm()
+    {
+        DialogResult = true;
+        RequestClose?.Invoke();
+    }
+
+    public bool? DialogResult { get; private set; }
+
+    public event Action? RequestClose;
+}

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics;
@@ -263,20 +263,41 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(IsVideoInitialized))]
     private async Task SaveFrameClickAsync()
     {
-        var defaultName = Path.GetFileNameWithoutExtension(VideoPath) + $"_{CommonUtil.FormatSeconds(CurrentTime, true)}.png";
-        var settings = new SaveFileDialogSettings
-        {
-            Title = LocalizationManager.Instance.String_SaveFrame,
-            SuggestedStartLocation =  new DesktopDialogStorageFolder(Path.GetDirectoryName(VideoPath)!),
-            SuggestedFileName = defaultName,
-            Filters = [new(LocalizationManager.Instance.String_PngImages, ["png"])],
-            DefaultExtension = "png"
-        };
-        var result = await _dialogService.ShowSaveFileDialogAsync(this, settings);
-        if (result is null) return;
+        if (DecodedBitmap is null) return;
 
-        using var stream = File.Create(result!.Path!.LocalPath);
-        DecodedBitmap?.Save(stream);
+        var captureVm = _dialogService.CreateViewModel<CaptureFrameViewModel>();
+        var dialogResult = await _dialogService.ShowDialogAsync(this, captureVm);
+        if (dialogResult != true) return;
+
+        if (captureVm.IsSaveToFile)
+        {
+            var defaultName = Path.GetFileNameWithoutExtension(VideoPath) + $"_{CommonUtil.FormatSeconds(CurrentTime, true)}";
+            var isPng = captureVm.IsPngFormat;
+            var ext = isPng ? "png" : "jpg";
+            var filterName = isPng
+                ? LocalizationManager.Instance.String_PngImages
+                : LocalizationManager.Instance.String_JpgImages;
+            var settings = new SaveFileDialogSettings
+            {
+                Title = LocalizationManager.Instance.String_SaveFrame,
+                SuggestedStartLocation = new DesktopDialogStorageFolder(Path.GetDirectoryName(VideoPath)!),
+                SuggestedFileName = defaultName + "." + ext,
+                Filters = [new(filterName, [ext])],
+                DefaultExtension = ext
+            };
+            var result = await _dialogService.ShowSaveFileDialogAsync(this, settings);
+            if (result is null) return;
+
+            using var stream = File.Create(result!.Path!.LocalPath);
+            if (isPng)
+                DecodedBitmap.Save(stream);
+            else
+                ImageUtil.SaveAsJpeg(DecodedBitmap, stream);
+        }
+        else
+        {
+            ImageUtil.CopyBitmapToClipboard(DecodedBitmap, captureVm.IsPngFormat);
+        }
     }
 
     [ObservableProperty]

--- a/src/TSCutter.GUI/Views/CaptureFrameView.axaml
+++ b/src/TSCutter.GUI/Views/CaptureFrameView.axaml
@@ -1,0 +1,57 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:TSCutter.GUI"
+        xmlns:viewModels="clr-namespace:TSCutter.GUI.ViewModels"
+        mc:Ignorable="d"
+        x:Class="TSCutter.GUI.Views.CaptureFrameView"
+        d:DataContext="{x:Static local:App.CaptureFrameDialog}"
+        x:DataType="viewModels:CaptureFrameViewModel"
+        Width="320" Height="240"
+        WindowStartupLocation="CenterOwner"
+        CanResize="False"
+        Title="{DynamicResource String.CaptureFrame.Title}">
+
+    <Grid Margin="12" RowDefinitions="Auto,Auto,Auto" ColumnDefinitions="*">
+        <Border Grid.Row="0" BorderBrush="Gray" BorderThickness="1"
+                Margin="0,0,0,8" Padding="8">
+            <StackPanel Spacing="6">
+                <TextBlock FontWeight="Bold" Text="{DynamicResource String.CaptureFrame.Action}" />
+                <RadioButton Content="{DynamicResource String.CaptureFrame.CopyToClipboard}"
+                             IsChecked="{Binding IsSaveToFile, Converter={x:Static local:App.InverseBoolConverter}}"
+                             GroupName="ActionGroup" />
+                <RadioButton Content="{DynamicResource String.CaptureFrame.SaveToFile}"
+                             IsChecked="{Binding IsSaveToFile}"
+                             GroupName="ActionGroup" />
+            </StackPanel>
+        </Border>
+
+        <Border Grid.Row="1" BorderBrush="Gray" BorderThickness="1"
+                Margin="0,0,0,8" Padding="8">
+            <StackPanel Spacing="6">
+                <TextBlock FontWeight="Bold" Text="{DynamicResource String.CaptureFrame.Format}" />
+                <RadioButton Content="PNG"
+                             IsChecked="{Binding IsPngFormat}"
+                             GroupName="FormatGroup" />
+                <RadioButton Content="JPG"
+                             IsChecked="{Binding IsPngFormat, Converter={x:Static local:App.InverseBoolConverter}}"
+                             GroupName="FormatGroup" />
+            </StackPanel>
+        </Border>
+
+        <StackPanel Grid.Row="2"
+                    Orientation="Horizontal"
+                    HorizontalAlignment="Right"
+                    Spacing="6">
+            <Button Content="{DynamicResource String.Ok}"
+                    Width="70"
+                    Command="{Binding ConfirmCommand}"
+                    IsDefault="True"/>
+            <Button Content="{DynamicResource String.Cancel}"
+                    Width="70"
+                    Command="{Binding CancelCommand}"
+                    IsCancel="True"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/src/TSCutter.GUI/Views/CaptureFrameView.axaml.cs
+++ b/src/TSCutter.GUI/Views/CaptureFrameView.axaml.cs
@@ -1,0 +1,22 @@
+using System;
+using Classic.Avalonia.Theme;
+using TSCutter.GUI.ViewModels;
+
+namespace TSCutter.GUI.Views;
+
+public partial class CaptureFrameView : ClassicWindow
+{
+    public CaptureFrameView()
+    {
+        InitializeComponent();
+        Loaded += OnInitialized;
+    }
+
+    private void OnInitialized(object? sender, EventArgs e)
+    {
+        if (DataContext is CaptureFrameViewModel vm)
+        {
+            vm.RequestClose += Close;
+        }
+    }
+}


### PR DESCRIPTION
This PR extends the Capture button functionality. Previously, clicking Capture would directly save the current frame as a PNG file. Now a modal dialog pops up, letting users choose between Copy to Clipboard or Save to File , and for either option, select PNG (default) or JPG format.

How it works

1. User clicks Capture → modal appears
2. Choose Copy to Clipboard or Save to File
3. Choose PNG (default) or JPG
4. Click OK:
   - Save to File → file dialog → writes .png or .jpg to disk
   - Copy to Clipboard → places bitmap ( SetBitmap ) or JPEG bytes ( public.jpeg ) on clipboard

---

扩展 Capture（截图） 按钮的功能。之前点击截图直接保存为 PNG 文件，现在弹出模态对话框，让用户选择 复制到剪贴板 或 保存到文件 ，两种操作都可以选择 PNG （默认）或 JPG 格式。

交互流程

1. 点击 Capture → 弹出选择对话框
2. 选择 复制到剪贴板 或 保存到文件
3. 选择 PNG （默认）或 JPG 格式
4. 点击确定：
   - 保存到文件 → 文件保存对话框 → 写入 .png 或 .jpg
   - 复制到剪贴板 → PNG 用 SetBitmap ，JPG 用 SkiaSharp 编码为 JPEG 字节再放入剪贴板