### PR TITLE
Add remaining time in OutputWindow

### DIFF
--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -77,6 +77,7 @@
     <x:String x:Key="String.MediaInfo.Copied">Copied!</x:String>
     <x:String x:Key="String.MediaInfo.Failed">Failed to load media info:</x:String>
     <x:String x:Key="String.Output.Title">Output...</x:String>
+    <x:String x:Key="String.Output.Remaining">Remaining:</x:String>
     <x:String x:Key="String.Settings.Title">Settings</x:String>
     <x:String x:Key="String.Settings.General">General</x:String>
     <x:String x:Key="String.Settings.Language">Language</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -77,6 +77,7 @@
     <x:String x:Key="String.MediaInfo.Copied">已复制!</x:String>
     <x:String x:Key="String.MediaInfo.Failed">无法加载媒体信息:</x:String>
     <x:String x:Key="String.Output.Title">输出...</x:String>
+    <x:String x:Key="String.Output.Remaining">剩余时间：</x:String>
     <x:String x:Key="String.Settings.Title">设置</x:String>
     <x:String x:Key="String.Settings.General">常规</x:String>
     <x:String x:Key="String.Settings.Language">语言</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -77,6 +77,7 @@
     <x:String x:Key="String.MediaInfo.Copied">已複製!</x:String>
     <x:String x:Key="String.MediaInfo.Failed">無法載入媒體資訊:</x:String>
     <x:String x:Key="String.Output.Title">輸出...</x:String>
+    <x:String x:Key="String.Output.Remaining">剩餘時間：</x:String>
     <x:String x:Key="String.Settings.Title">設定</x:String>
     <x:String x:Key="String.Settings.General">一般</x:String>
     <x:String x:Key="String.Settings.Language">語言</x:String>

--- a/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
@@ -1,4 +1,4 @@
-﻿using System;
+﻿﻿using System;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
@@ -23,8 +23,13 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     [NotifyPropertyChangedFor(nameof(SpeedStr))]
     public partial double Speed { get; set; }
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(RemainingTimeStr))]
+    public partial double RemainingSeconds { get; set; }
+
     public string PercentStr => $"{Percent:0.00}%";
     public string SpeedStr => $"{CommonUtil.FormatFileSize(Speed)}/s";
+    public string RemainingTimeStr => FormatRemainingTime(RemainingSeconds);
     public string? SourceFilePath { get; set; }
     public long StartPosition { get; set; }
     public long EndPosition { get; set; }
@@ -33,21 +38,27 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     
     private CancellationTokenSource _cts = new();
     private DateTime _lastUpdateTime;
+    private DateTime _startTime;
     private long _bytesCopied = 0;
+    private long _totalBytes;
 
     [RelayCommand]
     private async Task OutputAsync()
     {
         try
         {
-            _lastUpdateTime = DateTime.Now;
+            _totalBytes = EndPosition > 0 ? EndPosition - StartPosition : new FileInfo(SourceFilePath!).Length - StartPosition;
+            _startTime = DateTime.Now;
+            _lastUpdateTime = _startTime;
             await CommonUtil.CopyFileAsync(new FileInfo(SourceFilePath!), OutputPath!, StartPosition, EndPosition,
                 (percent, bytesCopied) =>
                 {
                     Percent = percent;
                     _bytesCopied += bytesCopied;
                     UpdateSpeed();
+                    UpdateRemainingTime();
                 }, _cts.Token);
+            RemainingSeconds = 0;
             DialogResult = true;
             RequestClose?.Invoke();
         } 
@@ -66,10 +77,26 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     private void UpdateSpeed()
     {
         var elapsedTime = (DateTime.Now - _lastUpdateTime).TotalSeconds;
-        if (elapsedTime < 1) return; // per second
+        if (elapsedTime < 1) return;
         Speed = _bytesCopied / elapsedTime;
         _lastUpdateTime = DateTime.Now;
         _bytesCopied = 0;
+    }
+
+    private void UpdateRemainingTime()
+    {
+        if (Speed <= 0 || Percent >= 100) return;
+        var remainingBytes = _totalBytes * (1 - Percent / 100.0);
+        RemainingSeconds = remainingBytes / Speed;
+    }
+
+    private static string FormatRemainingTime(double seconds)
+    {
+        if (seconds <= 0) return "--:--";
+        var ts = TimeSpan.FromSeconds(seconds);
+        if (ts.TotalHours >= 1)
+            return $"{(int)ts.TotalHours}:{ts.Minutes:D2}:{ts.Seconds:D2}";
+        return $"{ts.Minutes:D2}:{ts.Seconds:D2}";
     }
 
     [RelayCommand]

--- a/src/TSCutter.GUI/Views/OutputWindow.axaml
+++ b/src/TSCutter.GUI/Views/OutputWindow.axaml
@@ -1,4 +1,4 @@
-﻿<Window xmlns="https://github.com/avaloniaui"
+<Window xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -30,26 +30,27 @@
                        MaxWidth="400" />
 
             <!-- 中部内容：进度条 + 状态 -->
-            <StackPanel Grid.Row="1" Spacing="8" HorizontalAlignment="Stretch" VerticalAlignment="Center">
-                <ProgressBar Minimum="0" Maximum="100"
-                             ShowProgressText="False"
-                             Value="{Binding Percent}"
-                             Height="20" />
-                <Grid ColumnDefinitions="80,Auto,100"
-                      HorizontalAlignment="Center">
-                    <!-- 百分比 -->
-                    <TextBlock Grid.Column="0"
-                               Text="{Binding PercentStr}"
-                               HorizontalAlignment="Right" />
-                    <!-- 分隔符 -->
-                    <TextBlock Grid.Column="1"
-                               Text=" | "
+            <StackPanel Grid.Row="1" Spacing="6" HorizontalAlignment="Stretch" VerticalAlignment="Center">
+                <!-- 进度条 + 百分比覆盖 -->
+                <Grid>
+                    <ProgressBar Minimum="0" Maximum="100"
+                                 ShowProgressText="False"
+                                 Value="{Binding Percent}"
+                                 Height="20" />
+                    <TextBlock Text="{Binding PercentStr}"
                                HorizontalAlignment="Center"
-                               Margin="4,0" />
-                    <!-- 速度 -->
-                    <TextBlock Grid.Column="2"
-                               Text="{Binding SpeedStr}"
-                               HorizontalAlignment="Left" />
+                               VerticalAlignment="Center"
+                               FontWeight="Bold" />
+                </Grid>
+                <!-- 速度（左）+ 剩余时间（右） -->
+                <Grid>
+                    <TextBlock HorizontalAlignment="Left"
+                               Text="{Binding SpeedStr}" />
+                    <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                        <TextBlock Text="{DynamicResource String.Output.Remaining}" />
+                        <TextBlock Text=" " />
+                        <TextBlock Text="{Binding RemainingTimeStr}" FontWeight="Bold" />
+                    </StackPanel>
                 </Grid>
             </StackPanel>
 


### PR DESCRIPTION
## Summary
This PR enhances the output window to display the estimated remaining time during file export, and redesigns the status area layout for a cleaner look.

## Changes
- Estimated remaining time : Calculated in real-time based on current copy speed and remaining bytes ( remainingBytes ÷ speed ), displayed in MM:SS format
- Percentage overlaid on progress bar : The percentage text now sits centered on top of the progress bar instead of in a separate table row, making better use of vertical space
- Speed & remaining time aligned left/right : Speed is left-aligned, remaining time is right-aligned in a single row, eliminating the empty gaps caused by fixed-width grid columns
- Localization : Added String.Output.Remaining key for en-US , zh-CN , and zh-TW

---

## 概要
本次 PR 为输出窗口增加了 预估剩余时间 显示功能，并优化了状态区域布局，使其更加紧凑美观。

## 改动内容
- 预估剩余时间 ：根据当前复制速度和剩余字节数实时计算（ 剩余字节 ÷ 速度 ），以 MM:SS 格式显示
- 百分比嵌入进度条 ：百分比文字居中覆盖在进度条上，不再占用独立行，节省纵向空间
- 速度与剩余时间左右分列 ：速度左对齐、剩余时间右对齐，同处一行，解决了固定列宽导致的空白间隙问题
- 本地化 ：三种语言（简中 / 繁中 / 英文）均新增 String.Output.Remaining 键