### PR TITLE
Add batch export queue and card-based clip list

### DIFF
--- a/src/TSCutter.GUI/Converters/CountToVisibilityConverter.cs
+++ b/src/TSCutter.GUI/Converters/CountToVisibilityConverter.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace TSCutter.GUI.Converters;
+
+public class ZeroToVisibilityConverter : IValueConverter
+{
+    public static readonly ZeroToVisibilityConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int count)
+            return count == 0;
+        return false;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}
+
+public class PositiveToVisibilityConverter : IValueConverter
+{
+    public static readonly PositiveToVisibilityConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is int count)
+            return count > 0;
+        return false;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/TSCutter.GUI/Converters/NullToVisibilityConverter.cs
+++ b/src/TSCutter.GUI/Converters/NullToVisibilityConverter.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Globalization;
+using Avalonia.Data.Converters;
+
+namespace TSCutter.GUI.Converters;
+
+public class NullToVisibilityConverter : IValueConverter
+{
+    public static readonly NullToVisibilityConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return value is not null;
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -50,6 +50,7 @@
     <x:String x:Key="String.Table.EndTime">End Time</x:String>
     <x:String x:Key="String.Table.OutputSize">Output Size</x:String>
     <x:String x:Key="String.Table.OutputPath">Output Path</x:String>
+    <x:String x:Key="String.Table.Status">Status</x:String>
     <x:String x:Key="String.Navigate.MarkStart">Mark Start</x:String>
     <x:String x:Key="String.Navigate.MarkEnd">Mark End</x:String>
     <x:String x:Key="String.Navigate.AddClip">Add Clip</x:String>
@@ -63,6 +64,14 @@
     <x:String x:Key="String.Navigate.Next20">Next 20</x:String>
     <x:String x:Key="String.SaveClipTip">Save Current Clip</x:String>
     <x:String x:Key="String.SaveClip">Save Clip</x:String>
+    <x:String x:Key="String.ExportAll">Export All</x:String>
+    <x:String x:Key="String.ExportAllTip">Export all clips to the source directory</x:String>
+    <x:String x:Key="String.ExportAllConfirm">Export {0} clips to the source directory?&#10;&#10;Output: {1}</x:String>
+    <x:String x:Key="String.Clips.Done">Done</x:String>
+    <x:String x:Key="String.Clips.Failed">Failed</x:String>
+    <x:String x:Key="String.Clips.Cancelled">Cancelled</x:String>
+    <x:String x:Key="String.Clips.Empty">No clips</x:String>
+    <x:String x:Key="String.SizePrefix">Size: </x:String>
     <x:String x:Key="String.Ok">OK</x:String>
     <x:String x:Key="String.Cancel">Cancel</x:String>
     <x:String x:Key="String.Apply">Apply</x:String>
@@ -78,6 +87,8 @@
     <x:String x:Key="String.MediaInfo.Failed">Failed to load media info:</x:String>
     <x:String x:Key="String.Output.Title">Output...</x:String>
     <x:String x:Key="String.Output.Remaining">Remaining:</x:String>
+    <x:String x:Key="String.Output.QueueProgress">Queue:</x:String>
+    <x:String x:Key="String.Output.CancelRemaining">Cancel Remaining</x:String>
     <x:String x:Key="String.Settings.Title">Settings</x:String>
     <x:String x:Key="String.Settings.General">General</x:String>
     <x:String x:Key="String.Settings.Language">Language</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -50,6 +50,7 @@
     <x:String x:Key="String.Table.EndTime">结束时间</x:String>
     <x:String x:Key="String.Table.OutputSize">输出大小</x:String>
     <x:String x:Key="String.Table.OutputPath">输出路径</x:String>
+    <x:String x:Key="String.Table.Status">状态</x:String>
     <x:String x:Key="String.Navigate.MarkStart">标记起点</x:String>
     <x:String x:Key="String.Navigate.MarkEnd">标记终点</x:String>
     <x:String x:Key="String.Navigate.AddClip">添加片段</x:String>
@@ -63,6 +64,14 @@
     <x:String x:Key="String.Navigate.Next20">后 20</x:String>
     <x:String x:Key="String.SaveClipTip">保存当前片段</x:String>
     <x:String x:Key="String.SaveClip">保存片段</x:String>
+    <x:String x:Key="String.ExportAll">全部导出</x:String>
+    <x:String x:Key="String.ExportAllTip">将所有片段导出到源文件所在目录</x:String>
+    <x:String x:Key="String.ExportAllConfirm">将 {0} 个片段导出到源文件所在目录？&#10;&#10;输出目录：{1}</x:String>
+    <x:String x:Key="String.Clips.Done">完成</x:String>
+    <x:String x:Key="String.Clips.Failed">失败</x:String>
+    <x:String x:Key="String.Clips.Cancelled">已取消</x:String>
+    <x:String x:Key="String.Clips.Empty">无任何剪辑</x:String>
+    <x:String x:Key="String.SizePrefix">大小：</x:String>
     <x:String x:Key="String.Ok">确定</x:String>
     <x:String x:Key="String.Cancel">取消</x:String>
     <x:String x:Key="String.Apply">应用</x:String>
@@ -78,6 +87,8 @@
     <x:String x:Key="String.MediaInfo.Failed">无法加载媒体信息:</x:String>
     <x:String x:Key="String.Output.Title">输出...</x:String>
     <x:String x:Key="String.Output.Remaining">剩余时间：</x:String>
+    <x:String x:Key="String.Output.QueueProgress">队列进度：</x:String>
+    <x:String x:Key="String.Output.CancelRemaining">取消剩余</x:String>
     <x:String x:Key="String.Settings.Title">设置</x:String>
     <x:String x:Key="String.Settings.General">常规</x:String>
     <x:String x:Key="String.Settings.Language">语言</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -50,6 +50,7 @@
     <x:String x:Key="String.Table.EndTime">結束時間</x:String>
     <x:String x:Key="String.Table.OutputSize">輸出大小</x:String>
     <x:String x:Key="String.Table.OutputPath">輸出路徑</x:String>
+    <x:String x:Key="String.Table.Status">狀態</x:String>
     <x:String x:Key="String.Navigate.MarkStart">標記起點</x:String>
     <x:String x:Key="String.Navigate.MarkEnd">標記終點</x:String>
     <x:String x:Key="String.Navigate.AddClip">新增片段</x:String>
@@ -63,6 +64,14 @@
     <x:String x:Key="String.Navigate.Next20">後 20</x:String>
     <x:String x:Key="String.SaveClipTip">儲存目前片段</x:String>
     <x:String x:Key="String.SaveClip">儲存片段</x:String>
+    <x:String x:Key="String.ExportAll">全部匯出</x:String>
+    <x:String x:Key="String.ExportAllTip">將所有片段匯出到來源檔案所在目錄</x:String>
+    <x:String x:Key="String.ExportAllConfirm">將 {0} 個片段匯出到來源檔案所在目錄？&#10;&#10;輸出目錄：{1}</x:String>
+    <x:String x:Key="String.Clips.Done">完成</x:String>
+    <x:String x:Key="String.Clips.Failed">失敗</x:String>
+    <x:String x:Key="String.Clips.Cancelled">已取消</x:String>
+    <x:String x:Key="String.Clips.Empty">無任何剪輯</x:String>
+    <x:String x:Key="String.SizePrefix">大小：</x:String>
     <x:String x:Key="String.Ok">確定</x:String>
     <x:String x:Key="String.Cancel">取消</x:String>
     <x:String x:Key="String.Apply">套用</x:String>
@@ -78,6 +87,8 @@
     <x:String x:Key="String.MediaInfo.Failed">無法載入媒體資訊:</x:String>
     <x:String x:Key="String.Output.Title">輸出...</x:String>
     <x:String x:Key="String.Output.Remaining">剩餘時間：</x:String>
+    <x:String x:Key="String.Output.QueueProgress">佇列進度：</x:String>
+    <x:String x:Key="String.Output.CancelRemaining">取消剩餘</x:String>
     <x:String x:Key="String.Settings.Title">設定</x:String>
     <x:String x:Key="String.Settings.General">一般</x:String>
     <x:String x:Key="String.Settings.Language">語言</x:String>

--- a/src/TSCutter.GUI/Models/PickedClip.cs
+++ b/src/TSCutter.GUI/Models/PickedClip.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Threading;
 using CommunityToolkit.Mvvm.ComponentModel;
@@ -6,9 +6,18 @@ using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.Models;
 
+public enum ClipExportStatus
+{
+    Pending,
+    Exporting,
+    Done,
+    Failed,
+    Cancelled
+}
+
 public partial class PickedClip : ObservableObject
 {
-    private static long _idCounter = 0; // 跨所有实例计数
+    private static long _idCounter = 0;
     public long ClipID { get; } = Interlocked.Increment(ref _idCounter);
     
     public long StartPts {get; set;}
@@ -31,15 +40,38 @@ public partial class PickedClip : ObservableObject
     private long _endPosition = -1;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(OutputFileSizeStr), nameof(EstimatedSizeStr))]
+    [NotifyPropertyChangedFor(nameof(OutputFileSizeStr), nameof(EstimatedSizeStr), nameof(OutputFilePathStr))]
     private FileInfo? _outputFileInfo;
-    
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    private ClipExportStatus _exportStatus = ClipExportStatus.Pending;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
+    private double _exportPercent;
+
+    [ObservableProperty]
+    private bool _isSelected;
+
     public required FileInfo InFileInfo { get; init; }
 
     public string StartTimeStr => CommonUtil.FormatSeconds(StartTime);
     public string? OutputFileSizeStr => OutputFileInfo == null ? null : CommonUtil.FormatFileSize(OutputFileInfo.Length);
+    public string? OutputFilePathStr => OutputFileInfo?.FullName;
     public string EndTimeStr => EndTime < 0 ? "Inf." : CommonUtil.FormatSeconds(EndTime);
-    public string? EstimatedSizeStr => "Size: " + CommonUtil.FormatFileSize(
-        Math.Max(0, (EndPosition > 0 ? EndPosition : InFileInfo.Length) - StartPosition)
-    );
+    public string? EstimatedSizeStr => LocalizationManager.Instance.String_SizePrefix
+        + CommonUtil.FormatFileSize(
+            Math.Max(0, (EndPosition > 0 ? EndPosition : InFileInfo.Length) - StartPosition)
+        );
+
+    public string StatusText => ExportStatus switch
+    {
+        ClipExportStatus.Pending => "---",
+        ClipExportStatus.Exporting => $"{ExportPercent:0.0}%",
+        ClipExportStatus.Done => LocalizationManager.Instance.String_Clips_Done,
+        ClipExportStatus.Failed => LocalizationManager.Instance.String_Clips_Failed,
+        ClipExportStatus.Cancelled => LocalizationManager.Instance.String_Clips_Cancelled,
+        _ => "---"
+    };
 }

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -77,9 +77,20 @@ public partial class MainWindowViewModel : ViewModelBase
     [NotifyCanExecuteChangedFor(
         nameof(AddClipCommand), nameof(RemoveClipCommand), nameof(MarkClipStartCommand),
         nameof(MarkClipEndCommand), nameof(SaveVideoClickCommand), nameof(CloseVideoClickCommand),
-        nameof(SaveFrameClickCommand), nameof(ShowMediaInfoClickCommand)
+        nameof(SaveFrameClickCommand), nameof(ShowMediaInfoClickCommand), nameof(ExportAllCommand)
     )]
     public partial PickedClip? SelectedClip { get; set; }
+
+    partial void OnSelectedClipChanged(PickedClip? value)
+    {
+        foreach (var clip in Clips)
+            clip.IsSelected = clip == value;
+    }
+    
+    public void SelectClip(PickedClip clip)
+    {
+        SelectedClip = clip;
+    }
     
     [RelayCommand]
     private async Task JumpToStartTimeAsync(object? time)
@@ -560,6 +571,16 @@ public partial class MainWindowViewModel : ViewModelBase
             await MessageBox.ShowDialog(desktopApp.MainWindow!, message, title, MessageBoxButtons.Ok, icon);
         }
     }
+
+    private async Task<bool> ShowConfirmAsync(string message, string title = "TSCutter")
+    {
+        if (Application.Current?.ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktopApp)
+        {
+            var result = await MessageBox.ShowDialog(desktopApp.MainWindow!, message, title, MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+            return result == MessageBoxResult.Yes;
+        }
+        return false;
+    }
     
     [RelayCommand]
     private void DragOver(DragEventArgs? e)
@@ -604,6 +625,7 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     private bool HasSelectedClip => SelectedClip is not null;
+    private bool CanExportAll => Clips.Count > 0;
     public bool IsVideoInitialized => _videoInstance is { Inited: true };
     
     private async Task SaveVideoAsync()
@@ -638,6 +660,47 @@ public partial class MainWindowViewModel : ViewModelBase
             return;
         }
         SelectedClip!.OutputFileInfo = new FileInfo(dialogViewModel.OutputPath);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanExportAll))]
+    private async Task ExportAllAsync()
+    {
+        var sourceDir = Path.GetDirectoryName(Clips[0].InFileInfo.FullName)!;
+        var confirmMsg = string.Format(LocalizationManager.Instance.String_ExportAllConfirm, Clips.Count, sourceDir);
+        if (!await ShowConfirmAsync(confirmMsg)) return;
+
+        var tasks = new List<BatchTask>();
+        foreach (var clip in Clips)
+        {
+            var fileName = GenerateClipFileName(clip);
+            var destPath = Path.Combine(sourceDir, fileName);
+            tasks.Add(new BatchTask(clip.InFileInfo.FullName, destPath, clip.StartPosition, clip.EndPosition));
+            clip.ExportStatus = ClipExportStatus.Pending;
+        }
+
+        var dialogViewModel = _dialogService.CreateViewModel<OutputWindowViewModel>();
+        dialogViewModel.SetBatchTasks(tasks);
+        await _dialogService.ShowDialogAsync(this, dialogViewModel).ConfigureAwait(true);
+
+        var completedSet = dialogViewModel.CompletedTaskIndices.ToHashSet();
+        for (int i = 0; i < Clips.Count; i++)
+        {
+            if (completedSet.Contains(i))
+            {
+                Clips[i].ExportStatus = ClipExportStatus.Done;
+                Clips[i].OutputFileInfo = new FileInfo(tasks[i].DestinationPath);
+            }
+            else if (Clips[i].ExportStatus == ClipExportStatus.Exporting)
+            {
+                Clips[i].ExportStatus = ClipExportStatus.Cancelled;
+            }
+        }
+    }
+
+    private static string GenerateClipFileName(PickedClip clip)
+    {
+        var sourceName = Path.GetFileNameWithoutExtension(clip.InFileInfo.FullName);
+        return $"{sourceName}_clip{clip.ClipID}_({CommonUtil.FormatSeconds(clip.StartTime, true)}-{CommonUtil.FormatSeconds(clip.EndTime, true)}).ts";
     }
     
     private void BuildThemeMenuItems()

--- a/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
@@ -1,4 +1,5 @@
-﻿﻿using System;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
@@ -9,6 +10,8 @@ using HanumanInstitute.MvvmDialogs;
 using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.ViewModels;
+
+public record BatchTask(string SourcePath, string DestinationPath, long StartPosition, long EndPosition);
 
 public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewModel
 {
@@ -27,26 +30,71 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     [NotifyPropertyChangedFor(nameof(RemainingTimeStr))]
     public partial double RemainingSeconds { get; set; }
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(QueueProgressStr), nameof(QueueProgress))]
+    public partial int CurrentTaskIndex { get; set; }
+
+    [ObservableProperty]
+    public partial string CurrentFileName { get; set; } = "";
+
+    [ObservableProperty]
+    public partial string CancelButtonText { get; set; } = "";
+
+    public bool IsBatchMode => _tasks.Count > 0;
+    public int TotalTasks => _tasks.Count;
+    public double QueueProgress => TotalTasks > 0 ? CurrentTaskIndex * 100.0 / TotalTasks : 0;
+    public string QueueProgressStr => $"{CurrentTaskIndex} / {TotalTasks}";
+
     public string PercentStr => $"{Percent:0.00}%";
     public string SpeedStr => $"{CommonUtil.FormatFileSize(Speed)}/s";
     public string RemainingTimeStr => FormatRemainingTime(RemainingSeconds);
+
     public string? SourceFilePath { get; set; }
     public long StartPosition { get; set; }
     public long EndPosition { get; set; }
     public string? OutputPath { get; set; }
     public Exception? Exception { get; private set; }
     
+    private readonly List<BatchTask> _tasks = [];
+    public List<int> CompletedTaskIndices { get; } = [];
     private CancellationTokenSource _cts = new();
     private DateTime _lastUpdateTime;
     private DateTime _startTime;
     private long _bytesCopied = 0;
     private long _totalBytes;
+    private bool _batchCancelled;
+
+    public OutputWindowViewModel()
+    {
+        CancelButtonText = LocalizationManager.Instance.String_Cancel;
+    }
+
+    public void SetBatchTasks(List<BatchTask> tasks)
+    {
+        _tasks.AddRange(tasks);
+        OnPropertyChanged(nameof(IsBatchMode));
+        OnPropertyChanged(nameof(TotalTasks));
+        CancelButtonText = LocalizationManager.Instance.String_Output_CancelRemaining;
+    }
 
     [RelayCommand]
     private async Task OutputAsync()
     {
+        if (IsBatchMode)
+        {
+            await RunBatchAsync();
+        }
+        else
+        {
+            await RunSingleAsync();
+        }
+    }
+
+    private async Task RunSingleAsync()
+    {
         try
         {
+            CurrentFileName = Path.GetFileName(OutputPath!);
             _totalBytes = EndPosition > 0 ? EndPosition - StartPosition : new FileInfo(SourceFilePath!).Length - StartPosition;
             _startTime = DateTime.Now;
             _lastUpdateTime = _startTime;
@@ -72,6 +120,57 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
             DialogResult = false;
             RequestClose?.Invoke();
         }
+    }
+
+    private async Task RunBatchAsync()
+    {
+        _batchCancelled = false;
+        for (int i = 0; i < _tasks.Count; i++)
+        {
+            if (_batchCancelled)
+                break;
+
+            var task = _tasks[i];
+            CurrentTaskIndex = i;
+            CurrentFileName = Path.GetFileName(task.DestinationPath);
+            Percent = 0;
+            Speed = 0;
+            RemainingSeconds = 0;
+
+            try
+            {
+                _totalBytes = task.EndPosition > 0
+                    ? task.EndPosition - task.StartPosition
+                    : new FileInfo(task.SourcePath).Length - task.StartPosition;
+                _startTime = DateTime.Now;
+                _lastUpdateTime = _startTime;
+                _bytesCopied = 0;
+
+                await CommonUtil.CopyFileAsync(new FileInfo(task.SourcePath), task.DestinationPath,
+                    task.StartPosition, task.EndPosition,
+                    (percent, bytesCopied) =>
+                    {
+                        Percent = percent;
+                        _bytesCopied += bytesCopied;
+                        UpdateSpeed();
+                        UpdateRemainingTime();
+                    }, _cts.Token);
+                CompletedTaskIndices.Add(i);
+            }
+            catch (OperationCanceledException)
+            {
+                _batchCancelled = true;
+            }
+            catch (Exception e)
+            {
+                Console.Error.WriteLine($"Task failed: {e.Message}");
+            }
+        }
+
+        CurrentTaskIndex = _batchCancelled ? CurrentTaskIndex : _tasks.Count;
+        RemainingSeconds = 0;
+        DialogResult = true;
+        RequestClose?.Invoke();
     }
     
     private void UpdateSpeed()
@@ -103,10 +202,18 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     private void CancelOutput()
     {
         if (DialogResult is not null) return;
-        
-        _cts.Cancel();
-        DialogResult = true;
-        RequestClose?.Invoke();
+
+        if (IsBatchMode)
+        {
+            _batchCancelled = true;
+            _cts.Cancel();
+        }
+        else
+        {
+            _cts.Cancel();
+            DialogResult = true;
+            RequestClose?.Invoke();
+        }
     }
     
     public void OnClosing(CancelEventArgs e)

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -101,6 +101,8 @@
                         <MenuItem Header="{DynamicResource String.Menu.SaveClip}"
                                   Command="{Binding SaveVideoClickCommand}"
                                   InputGesture="{OnPlatform Ctrl+S, macOS=⌘+S}" />
+                        <MenuItem Header="{DynamicResource String.ExportAll}"
+                                  Command="{Binding ExportAllCommand}" />
                         <Separator />
                         <MenuItem Header="{DynamicResource String.Menu.CloseVideo}"
                                   Command="{Binding CloseVideoClickCommand}"/>
@@ -221,65 +223,104 @@
                                 </controls:ImageViewer>
                             </ClassicBorderDecorator>
                             <GridSplitter Grid.Column="1" Width="3" />
-                            <ScrollViewer Grid.Column="2">
-                                <DataGrid x:Name="MyDataGrid"
-                                          SelectionMode="Single"
-                                          SelectedItem="{Binding SelectedClip}"
-                                          ItemsSource="{Binding Clips}"
-                                          IsReadOnly="True"
-                                          CanUserResizeColumns="True"
-                                          CanUserSortColumns="False"
-                                          AutoGenerateColumns="False">
-                                    <DataGrid.Styles>
-                                        <Style Selector="DataGridCell">
-                                            <Setter Property="Padding" Value="2,0"/>
-                                        </Style>
-                                    </DataGrid.Styles>
-                                    <DataGrid.Columns>
-                                        <DataGridTextColumn Width="25"
-                                                            Header="ID"
-                                                            Binding="{Binding ClipID}" />
-                                        <DataGridTemplateColumn Header="{DynamicResource String.Table.StartTime}" MinWidth="85">
-                                            <DataGridTemplateColumn.CellTemplate>
+                            <ClassicBorderDecorator Grid.Column="2" BorderThickness="2" BorderStyle="Sunken">
+                                <DockPanel>
+                                    <!-- Export All button pinned at bottom -->
+                                    <Button DockPanel.Dock="Bottom"
+                                            Command="{Binding ExportAllCommand}"
+                                            HorizontalAlignment="Stretch"
+                                            ToolTip.Tip="{DynamicResource String.ExportAllTip}"
+                                            Margin="0,2,0,0">
+                                        <TextBlock Text="{DynamicResource String.ExportAll}" />
+                                    </Button>
+                                    <Grid>
+                                        <!-- Empty state -->
+                                        <TextBlock Text="{DynamicResource String.Clips.Empty}"
+                                                   HorizontalAlignment="Center"
+                                                   VerticalAlignment="Center"
+                                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                   IsVisible="{Binding Clips.Count, Converter={x:Static converters:ZeroToVisibilityConverter.Instance}}" />
+                                        <!-- Cards -->
+                                        <ScrollViewer Name="ClipsScrollViewer"
+                                                      HorizontalScrollBarVisibility="Disabled"
+                                                      IsVisible="{Binding Clips.Count, Converter={x:Static converters:PositiveToVisibilityConverter.Instance}}">
+                                            <ItemsControl ItemsSource="{Binding Clips}">
+                                            <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <!-- 需要让Button继承DataGridCell的Foreground -->
-                                                    <Button Content="{Binding StartTimeStr}"
-                                                            HorizontalAlignment="Left"
-                                                            Classes="hyperlink"
-                                                            Foreground="{Binding RelativeSource={RelativeSource AncestorType=DataGridCell}, Path=Foreground}"
-                                                            Command="{Binding #MyDataGrid.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
-                                                            CommandParameter="{Binding}" />
+                                                    <Border Margin="0,0,0,4"
+                                                            Padding="6"
+                                                            Classes.selected="{Binding IsSelected}"
+                                                            PointerPressed="ClipCard_OnPointerPressed">
+                                                        <Border.Styles>
+                                                            <Style Selector="Border">
+                                                                <Setter Property="Background" Value="Transparent" />
+                                                            </Style>
+                                                            <Style Selector="Border.selected">
+                                                                <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}" />
+                                                            </Style>
+                                                        </Border.Styles>
+                                                        <Grid>
+                                                            <!-- Unselected: Raised border -->
+                                                            <ClassicBorderDecorator BorderThickness="2" BorderStyle="Raised"
+                                                                                    IsVisible="{Binding IsSelected, Converter={x:Static local:App.InverseBoolConverter}}" />
+                                                            <!-- Selected: Sunken border -->
+                                                            <ClassicBorderDecorator BorderThickness="2" BorderStyle="Sunken"
+                                                                                    IsVisible="{Binding IsSelected}" />
+                                                            <!-- Content -->
+                                                            <StackPanel Margin="4" Spacing="2">
+                                                                <!-- Header: ID + Status -->
+                                                                <Grid ColumnDefinitions="Auto,*,Auto">
+                                                                    <TextBlock Text="{Binding ClipID, StringFormat='#{0}'}"
+                                                                               FontWeight="Bold"
+                                                                               FontSize="12" />
+                                                                    <TextBlock Grid.Column="2"
+                                                                               Text="{Binding StatusText}" />
+                                                                </Grid>
+                                                                <!-- Start time -->
+                                                                <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                    <TextBlock Text="{DynamicResource String.Table.StartTime}"
+                                                                               Margin="0,0,4,0"
+                                                                               VerticalAlignment="Center" />
+                                                                    <Button Grid.Column="1"
+                                                                            Content="{Binding StartTimeStr}"
+                                                                            Classes="hyperlink"
+                                                                            Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
+                                                                            CommandParameter="{Binding}" />
+                                                                </Grid>
+                                                                <!-- End time -->
+                                                                <Grid ColumnDefinitions="Auto,*">
+                                                                    <TextBlock Text="{DynamicResource String.Table.EndTime}"
+                                                                               Margin="0,0,4,0"
+                                                                               VerticalAlignment="Center" />
+                                                                    <Button Grid.Column="1"
+                                                                            Content="{Binding EndTimeStr}"
+                                                                            Classes="hyperlink"
+                                                                            Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
+                                                                            CommandParameter="{Binding}" />
+                                                                </Grid>
+                                                                <!-- Size + Output Path -->
+                                                                <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                    <TextBlock Text="{Binding EstimatedSizeStr}"
+                                                                               VerticalAlignment="Center"
+                                                                               Margin="0,0,8,0" />
+                                                                    <Button Grid.Column="1"
+                                                                            Content="{Binding OutputFilePathStr}"
+                                                                            Classes="hyperlink"
+                                                                            HorizontalContentAlignment="Stretch"
+                                                                            IsVisible="{Binding OutputFileInfo, Converter={x:Static converters:NullToVisibilityConverter.Instance}}"
+                                                                            Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).FindFileCommand}"
+                                                                            CommandParameter="{Binding OutputFileInfo}" />
+                                                                </Grid>
+                                                            </StackPanel>
+                                                        </Grid>
+                                                    </Border>
                                                 </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                        <DataGridTemplateColumn Header="{DynamicResource String.Table.EndTime}" MinWidth="85">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <Button Content="{Binding EndTimeStr}"
-                                                            HorizontalAlignment="Left"
-                                                            Classes="hyperlink"
-                                                            Foreground="{Binding RelativeSource={RelativeSource AncestorType=DataGridCell}, Path=Foreground}"
-                                                            Command="{Binding #MyDataGrid.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
-                                                            CommandParameter="{Binding}" />
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                        <DataGridTextColumn Header="{DynamicResource String.Table.OutputSize}" MinWidth="85"
-                                                            Binding="{Binding OutputFileSizeStr}" />
-                                        <DataGridTemplateColumn Header="{DynamicResource String.Table.OutputPath}" MinWidth="85" Width="*">
-                                            <DataGridTemplateColumn.CellTemplate>
-                                                <DataTemplate>
-                                                    <Button Content="{Binding OutputFileInfo.FullName}"
-                                                            Classes="hyperlink"
-                                                            Foreground="{Binding RelativeSource={RelativeSource AncestorType=DataGridCell}, Path=Foreground}"
-                                                            Command="{Binding #MyDataGrid.((vm:MainWindowViewModel)DataContext).FindFileCommand}"
-                                                            CommandParameter="{Binding OutputFileInfo}" />
-                                                </DataTemplate>
-                                            </DataGridTemplateColumn.CellTemplate>
-                                        </DataGridTemplateColumn>
-                                    </DataGrid.Columns>
-                                </DataGrid>
-                            </ScrollViewer>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                    </ScrollViewer>
+                                </Grid>
+                                </DockPanel>
+                            </ClassicBorderDecorator>
                         </Grid>
                         <!-- 滑块 -->
                         <controls:CustomSlider Grid.Row="1"

--- a/src/TSCutter.GUI/Views/MainWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml.cs
@@ -1,13 +1,14 @@
 using System;
+using System.Collections.Specialized;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
 using Classic.Avalonia.Theme;
 using CommunityToolkit.Mvvm.Messaging;
 using TSCutter.GUI.Models;
 using TSCutter.GUI.ViewModels;
 
 namespace TSCutter.GUI.Views;
-
-// https://dccn.blob.core.windows.net/2022/Slide/%E5%BC%80%E6%BA%90_B6_%E5%91%A8%E6%9D%B0_.NET%20%E7%8E%A9%E8%BD%AC%E9%9F%B3%E8%A7%86%E9%A2%91%E6%93%8D%E4%BD%9C%20FFmpeg.pdf
 
 public partial class MainWindow : ClassicWindow
 {
@@ -17,7 +18,6 @@ public partial class MainWindow : ClassicWindow
     {
         InitializeComponent();
 
-        // 监听 ViewModel 发送的 FitMessage
         WeakReferenceMessenger.Default.Register<FitMessage>(this, (r, m) =>
         {
             if (ImageViewer.FitCommand.CanExecute(null))
@@ -25,11 +25,38 @@ public partial class MainWindow : ClassicWindow
                 ImageViewer.FitCommand.Execute(null);
             }
         });
+
+        DataContextChanged += (_, _) =>
+        {
+            if (DataContext is MainWindowViewModel vm)
+            {
+                vm.Clips.CollectionChanged += OnClipsCollectionChanged;
+            }
+        };
+    }
+
+    private void OnClipsCollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
+    {
+        if (e.Action == NotifyCollectionChangedAction.Add)
+        {
+            Dispatcher.UIThread.Post(() =>
+            {
+                ClipsScrollViewer.ScrollToEnd();
+            }, DispatcherPriority.Loaded);
+        }
     }
 
     private void Window_OnClosing(object? sender, WindowClosingEventArgs e)
     {
         ViewModel.Close();
+    }
+
+    private void ClipCard_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is Border { DataContext: PickedClip clip })
+        {
+            ViewModel.SelectClip(clip);
+        }
     }
 
     private async void CustomSlider_OnValueChangedAfterMouseUp(object? sender, double e)

--- a/src/TSCutter.GUI/Views/OutputWindow.axaml
+++ b/src/TSCutter.GUI/Views/OutputWindow.axaml
@@ -4,6 +4,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:TSCutter.GUI"
         xmlns:viewModels="clr-namespace:TSCutter.GUI.ViewModels"
+        xmlns:converters="clr-namespace:TSCutter.GUI.Converters"
         mc:Ignorable="d"
         Height="180" Width="420"
         x:Class="TSCutter.GUI.Views.OutputWindow"
@@ -14,6 +15,10 @@
         x:DataType="viewModels:OutputWindowViewModel"
         Title="{DynamicResource String.Output.Title}">
 
+    <Window.Resources>
+        <converters:InverseBoolConverter x:Key="InverseBoolConverter" />
+    </Window.Resources>
+
     <Interaction.Behaviors>
         <RoutedEventTriggerBehavior RoutedEvent="{x:Static Control.LoadedEvent}">
             <InvokeCommandAction Command="{Binding OutputCommand}" />
@@ -22,36 +27,50 @@
 
     <Border BorderThickness="2" Padding="8">
         <Grid RowDefinitions="Auto,*,Auto">
-            <!-- 顶部路径 -->
+            <!-- 顶部文件名 -->
             <TextBlock Grid.Row="0"
-                       Text="{Binding OutputPath}"
+                       Text="{Binding CurrentFileName}"
                        Margin="0,0,0,8"
-                       TextWrapping="Wrap"
+                       TextWrapping="NoWrap"
+                       TextTrimming="CharacterEllipsis"
                        MaxWidth="400" />
 
             <!-- 中部内容：进度条 + 状态 -->
             <StackPanel Grid.Row="1" Spacing="6" HorizontalAlignment="Stretch" VerticalAlignment="Center">
-                <!-- 进度条 + 百分比覆盖 -->
-                <Grid>
-                    <ProgressBar Minimum="0" Maximum="100"
-                                 ShowProgressText="False"
-                                 Value="{Binding Percent}"
-                                 Height="20" />
-                    <TextBlock Text="{Binding PercentStr}"
-                               HorizontalAlignment="Center"
-                               VerticalAlignment="Center"
+                <!-- 当前任务进度条 -->
+                <ProgressBar Minimum="0" Maximum="100"
+                             ShowProgressText="False"
+                             Value="{Binding Percent}"
+                             Height="20" />
+                <!-- 百分比（左）+ 速度（中）+ 剩余时间（右） -->
+                <Grid ColumnDefinitions="Auto, *, Auto">
+                    <TextBlock Grid.Column="0"
+                               Text="{Binding PercentStr}"
                                FontWeight="Bold" />
-                </Grid>
-                <!-- 速度（左）+ 剩余时间（右） -->
-                <Grid>
-                    <TextBlock HorizontalAlignment="Left"
-                               Text="{Binding SpeedStr}" />
-                    <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                    <TextBlock Grid.Column="1"
+                               Text="{Binding SpeedStr}"
+                               HorizontalAlignment="Center" />
+                    <StackPanel Grid.Column="2" Orientation="Horizontal">
                         <TextBlock Text="{DynamicResource String.Output.Remaining}" />
                         <TextBlock Text=" " />
                         <TextBlock Text="{Binding RemainingTimeStr}" FontWeight="Bold" />
                     </StackPanel>
                 </Grid>
+                <!-- 队列进度（仅批量模式） -->
+                <StackPanel IsVisible="{Binding IsBatchMode}" Spacing="4">
+                    <Border Height="1" Margin="0,4,0,4" Background="{DynamicResource SystemBaseLowColor}" />
+                    <Grid>
+                        <TextBlock HorizontalAlignment="Left"
+                                   Text="{DynamicResource String.Output.QueueProgress}" />
+                        <TextBlock HorizontalAlignment="Right"
+                                   Text="{Binding QueueProgressStr}"
+                                   FontWeight="Bold" />
+                    </Grid>
+                    <ProgressBar Minimum="0" Maximum="100"
+                                 ShowProgressText="False"
+                                 Value="{Binding QueueProgress}"
+                                 Height="14" />
+                </StackPanel>
             </StackPanel>
 
             <!-- 底部分隔线 + 按钮区 -->
@@ -64,10 +83,10 @@
                     </Grid.ColumnDefinitions>
 
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" HorizontalAlignment="Right">
-                        <Button Content="{DynamicResource String.Cancel}"
-                                Width="80"
+                        <Button Width="120"
                                 HorizontalAlignment="Right"
-                                Command="{Binding CancelOutputCommand}" />
+                                Command="{Binding CancelOutputCommand}"
+                                Content="{Binding CancelButtonText}" />
                     </StackPanel>
                 </Grid>
             </StackPanel>

--- a/src/TSCutter.GUI/Views/OutputWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/OutputWindow.axaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Classic.Avalonia.Theme;
 using TSCutter.GUI.ViewModels;
 
@@ -14,10 +14,11 @@ public partial class OutputWindow : ClassicWindow
     
     private void OnInitialized(object? sender, EventArgs e)
     {
-        // 订阅关闭请求
         if (DataContext is OutputWindowViewModel vm)
         {
             vm.RequestClose += Close;
+            if (vm.IsBatchMode)
+                Height = 280;
         }
     }
 }


### PR DESCRIPTION
**Summary:**
This PR introduces a batch export queue system with a redesigned output window, and replaces the DataGrid with a Win98-style card layout for better UX.

**New Features:**
- **Batch Export Queue**: Export all clips in one operation with dual progress bars (current task + overall queue)
- **Card-Based UI**: Clips now display as individual cards with Raised/Sunken borders (Win98 style)
- **Queue Progress**: Shows current file name, speed, estimated remaining time, and queue counter (e.g., "2 / 4")
- **Empty State**: Displays "No clips" placeholder when the list is empty
- **Auto-scroll**: Automatically scrolls to the bottom when a new clip is added
- **Export All Button**: Pinned at the bottom of the clip panel + accessible from File menu

**Improvements:**
- Output window shows estimated remaining time based on current speed
- Percent text moved below progress bar for better readability
- Layout: `percent | speed | remaining time` in clean three-column row
- Confirmation dialog before batch export with proper XML newline rendering (`&#10;`)
- Fixed output path displaying type name instead of actual file path
- Localized "Size:" prefix (12 new keys across en-US, zh-CN, zh-TW)

**New Converters:**
- `NullToVisibilityConverter`: null → hidden
- `ZeroToVisibilityConverter`: 0 → visible
- `PositiveToVisibilityConverter`: >0 → visible

**Files Changed:** 12 files, +665 / -283 lines

---

**概要：**
本 PR 引入批量导出队列系统和重新设计的输出窗口，并将 DataGrid 替换为 Win98 风格卡片布局以提升用户体验。

**新增功能：**
- **批量导出队列**：一次性导出所有片段，双进度条显示（当前任务 + 整体队列）
- **卡片式界面**：片段以独立卡片形式展示，带有凸起/凹陷边框（Win98 风格）
- **队列进度**：显示当前文件名、速度、预估剩余时间、队列计数器（如 "2 / 4"）
- **空状态**：列表为空时显示"无任何剪辑"占位文字
- **自动滚动**：添加新片段时自动滚动到底部
- **全部导出按钮**：固定在片段面板底部 + 文件菜单入口

**改进：**
- 输出窗口显示基于当前速度计算的预估剩余时间
- 百分比文字移至进度条下方以提升可读性
- 布局：`百分比 | 速度 | 剩余时间` 采用简洁的三列排布
- 批量导出前弹出确认对话框，使用正确的 XML 换行符（`&#10;`）
- 修复输出路径显示为类型名而非实际文件路径的问题
- 本地化 "Size:" 前缀（en-US、zh-CN、zh-TW 共 12 个新键）

**新增转换器：**
- `NullToVisibilityConverter`：null → 隐藏
- `ZeroToVisibilityConverter`：0 → 显示
- `PositiveToVisibilityConverter`：>0 → 显示
