### PR TITLE
Optimize video decoding and frame rendering performance

### DIFF
--- a/src/TSCutter.GUI/Models/VideoInstance.cs
+++ b/src/TSCutter.GUI/Models/VideoInstance.cs
@@ -264,7 +264,7 @@ public class VideoInstance(string filePath) : IDisposable
     /// 仅读取 packet 级别的 PTS 来计算关键帧间隔，不执行真正的帧解码。
     /// 用于 InitVideo 阶段快速估算 keyFrameGap。
     /// </summary>
-    private (long firstPts, long gap) ReadKeyFramePacketPts(int requiredKeyFrames = 2)
+    private (long firstPts, long gap) ReadKeyFramePacketPts(int requiredKeyFrames = 3)
     {
         var keyFramePtsList = new List<long>();
         foreach (var packet in inFc.ReadPackets(videoStreamIndex))
@@ -282,7 +282,7 @@ public class VideoInstance(string filePath) : IDisposable
         if (keyFramePtsList.Count < 2)
             return (keyFramePtsList.Count > 0 ? keyFramePtsList[0] : 0, 0);
 
-        var gap = Math.Abs(keyFramePtsList[1] - keyFramePtsList[0]);
+        var gap = Math.Abs(keyFramePtsList[^1] - keyFramePtsList[^2]);
         Console.WriteLine($"KeyFramePacket PTS: {string.Join(", ", keyFramePtsList)}, gap: {gap}");
         return (keyFramePtsList[0], gap);
     }

--- a/src/TSCutter.GUI/Models/VideoInstance.cs
+++ b/src/TSCutter.GUI/Models/VideoInstance.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -88,12 +88,11 @@ public class VideoInstance(string filePath) : IDisposable
 
         try
         {
-            // calc KeyFrameGap
-            DecodeNextFrame();
-            DecodeNextFrame();
-            var firstKeyFramePts = currentKeyFramePts;
-            DecodeNextFrame();
-            keyFrameGap = Math.Abs(currentKeyFramePts - firstKeyFramePts);
+            // calc KeyFrameGap from packet-level PTS (no frame decoding needed)
+            var (firstPts, gap) = ReadKeyFramePacketPts();
+            firstFrameTimestamp = firstPts;
+            maxPts = inVideoStream.Duration + firstFrameTimestamp;
+            keyFrameGap = gap;
             Console.WriteLine($"keyFrameGap: {keyFrameGap}");
             Seek(firstFrameTimestamp);
         }
@@ -259,6 +258,33 @@ public class VideoInstance(string filePath) : IDisposable
         var durationInSeconds = inVideoStream.GetDurationInSeconds();
         var fileSize = inFc.GetFileSize();
         return $"{inVideoStream.Codecpar.CodecId}, {width}x{height}, {FormatSeconds(durationInSeconds)}, {FormatFileSize(fileSize)}";
+    }
+
+    /// <summary>
+    /// 仅读取 packet 级别的 PTS 来计算关键帧间隔，不执行真正的帧解码。
+    /// 用于 InitVideo 阶段快速估算 keyFrameGap。
+    /// </summary>
+    private (long firstPts, long gap) ReadKeyFramePacketPts(int requiredKeyFrames = 2)
+    {
+        var keyFramePtsList = new List<long>();
+        foreach (var packet in inFc.ReadPackets(videoStreamIndex))
+        {
+            if (packet.StreamIndex != videoStreamIndex || packet.Pts < 0)
+                continue;
+            if ((packet.Flags & AV_PKT_FLAG_KEY_FRAME) == 0)
+                continue;
+
+            keyFramePtsList.Add(packet.Pts);
+            if (keyFramePtsList.Count >= requiredKeyFrames)
+                break;
+        }
+
+        if (keyFramePtsList.Count < 2)
+            return (keyFramePtsList.Count > 0 ? keyFramePtsList[0] : 0, 0);
+
+        var gap = Math.Abs(keyFramePtsList[1] - keyFramePtsList[0]);
+        Console.WriteLine($"KeyFramePacket PTS: {string.Join(", ", keyFramePtsList)}, gap: {gap}");
+        return (keyFramePtsList[0], gap);
     }
 
     public void Close()

--- a/src/TSCutter.GUI/Utils/ImageUtil.cs
+++ b/src/TSCutter.GUI/Utils/ImageUtil.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Globalization;
 using System.IO;
-using System.Runtime.InteropServices;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Input;
@@ -19,44 +18,49 @@ public static class ImageUtil
 {
     // 每次都创建一张纯黑图片作为音频的图
     public static Bitmap BlankImage => CreateAudioBitmap();
-    
-    public static Bitmap CreateBitmapFromFrame(Frame frame, int dpi = 96)
+
+    // 缓存 VideoFrameConverter，避免每帧重新初始化 swscale 上下文
+    private static VideoFrameConverter? _cachedSws;
+    private static int _cachedWidth;
+    private static int _cachedHeight;
+
+    public static unsafe Bitmap CreateBitmapFromFrame(Frame frame, int dpi = 96)
     {
         var width = frame.Width;
         var height = frame.Height;
-        using VideoFrameConverter sws = new();
-        using Frame dest = Frame.CreateVideo(width, height, AVPixelFormat.Bgr24);
-        sws.ConvertFrame(frame, dest);
-        
+
+        // swscale 直接输出 BGRA 格式，消除逐像素 BGR→BGRA 转换
+        if (_cachedSws == null || _cachedWidth != width || _cachedHeight != height)
+        {
+            _cachedSws?.Dispose();
+            _cachedSws = new VideoFrameConverter();
+            _cachedWidth = width;
+            _cachedHeight = height;
+        }
+
+        using Frame dest = Frame.CreateVideo(width, height, AVPixelFormat.Bgra);
+        _cachedSws.ConvertFrame(frame, dest);
+
         var writableBitmap = new WriteableBitmap(
-            new PixelSize(width, height), 
-            new Vector(dpi, dpi), 
-            PixelFormat.Bgra8888, 
+            new PixelSize(width, height),
+            new Vector(dpi, dpi),
+            PixelFormat.Bgra8888,
             AlphaFormat.Opaque);
 
         using var buffer = writableBitmap.Lock();
-        var destData = dest.Data[0]; // dest frame data。
-        var stride = dest.Linesize[0]; // bytes per line。
+        var srcData = dest.Data[0];
+        var srcStride = dest.Linesize[0];
+        var destRowBytes = buffer.RowBytes;
 
+        // swscale 已输出 BGRA，整行 MemoryCopy 替代逐字节 Marshal 操作
+        var copyBytesPerRow = Math.Min(srcStride, destRowBytes);
         for (var y = 0; y < height; y++)
         {
-            var sourcePtr = destData + y * stride;
-            var destPtr = buffer.Address + y * buffer.RowBytes;
-        
-            for (var x = 0; x < width; x++)
-            {
-                var blue = Marshal.ReadByte(sourcePtr + x * 3);
-                var green = Marshal.ReadByte(sourcePtr + x * 3 + 1);
-                var red = Marshal.ReadByte(sourcePtr + x * 3 + 2);
-
-                // write BGRA data
-                Marshal.WriteByte(destPtr + x * 4, blue);
-                Marshal.WriteByte(destPtr + x * 4 + 1, green);
-                Marshal.WriteByte(destPtr + x * 4 + 2, red);
-                Marshal.WriteByte(destPtr + x * 4 + 3, 255); // set alpha to 255
-            }
+            var srcPtr = srcData + y * srcStride;
+            var destPtr = buffer.Address + y * destRowBytes;
+            Buffer.MemoryCopy((void*)srcPtr, (void*)destPtr, destRowBytes, copyBytesPerRow);
         }
-        
+
         return writableBitmap;
     }
 


### PR DESCRIPTION
- Compute keyFrameGap from packet-level PTS during InitVideo instead of fully decoding 3 frames, eliminating unnecessary bitmap allocations and swscale operations at startup
- Convert frames directly to BGRA via swscale, removing the per-pixel BGR→BGRA conversion loop (~4M Marshal calls for 1080p)
- Replace per-byte Marshal.ReadByte/WriteByte with Buffer.MemoryCopy for row-by-row pixel transfer
- Cache VideoFrameConverter across frames to avoid reinitializing swscale context per decode
- Improve keyFrameGap accuracy by sampling more keyframes and using the last interval instead of the first (avoids estimation bias from incomplete initial GOP)

---

- InitVideo 阶段改为从 packet 级别 PTS 计算 keyFrameGap，不再完整解码 3 帧，避免不必要的 Bitmap 分配和 swscale 运算
- swscale 直接输出 BGRA 格式，消除逐像素 BGR→BGRA 转换循环（1080p 约 415 万次 Marshal 调用）
- 像素拷贝从逐字节 Marshal.ReadByte/WriteByte 改为 Buffer.MemoryCopy 整行复制
- 缓存 VideoFrameConverter，避免每帧重新初始化 swscale 上下文
- keyFrameGap 采样更多关键帧并使用末尾间隔计算，避免首个不完整 GOP 导致的估算偏差