### PR TITLE
Add cross-file export queue

### DIFF
--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -22,6 +22,7 @@
     <x:String x:Key="String.Menu.File">_File</x:String>
     <x:String x:Key="String.Menu.OpenVideo">_Open Video...</x:String>
     <x:String x:Key="String.Menu.SaveClip">_Save Clip...</x:String>
+    <x:String x:Key="String.Menu.ExportQueue">Export Queue</x:String>
     <x:String x:Key="String.Menu.CloseVideo">_Close Video</x:String>
     <x:String x:Key="String.Menu.Exit">_Exit</x:String>
     <x:String x:Key="String.Menu.Tools">_Tools</x:String>
@@ -127,4 +128,14 @@
     <x:String x:Key="String.CaptureFrame.CopyToClipboard">Copy to Clipboard</x:String>
     <x:String x:Key="String.CaptureFrame.SaveToFile">Save to File</x:String>
     <x:String x:Key="String.CaptureFrame.Format">Format</x:String>
+    <x:String x:Key="String.AddToQueue">Add to Queue...</x:String>
+    <x:String x:Key="String.AddToQueueTip">Add current clip to export queue</x:String>
+    <x:String x:Key="String.BatchExportQueue">Batch Export</x:String>
+    <x:String x:Key="String.BatchExportQueueTip">Export all clips in the queue</x:String>
+    <x:String x:Key="String.BatchExportConfirm">Export {0} clips from the queue?&#10;&#10;Continue?</x:String>
+    <x:String x:Key="String.ExportQueue">Export Queue</x:String>
+    <x:String x:Key="String.QueueEmpty">Queue is empty</x:String>
+    <x:String x:Key="String.ClearQueue">Clear Queue</x:String>
+    <x:String x:Key="String.Clips">Clips</x:String>
+    <x:String x:Key="String.QueueRemove">Remove</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -22,6 +22,7 @@
     <x:String x:Key="String.Menu.File">文件(_F)</x:String>
     <x:String x:Key="String.Menu.OpenVideo">打开视频(_O)...</x:String>
     <x:String x:Key="String.Menu.SaveClip">保存片段(_S)...</x:String>
+    <x:String x:Key="String.Menu.ExportQueue">导出队列</x:String>
     <x:String x:Key="String.Menu.CloseVideo">关闭视频</x:String>
     <x:String x:Key="String.Menu.Exit">退出(_E)</x:String>
     <x:String x:Key="String.Menu.Tools">工具(_T)</x:String>
@@ -127,4 +128,14 @@
     <x:String x:Key="String.CaptureFrame.CopyToClipboard">复制到剪贴板</x:String>
     <x:String x:Key="String.CaptureFrame.SaveToFile">保存到文件</x:String>
     <x:String x:Key="String.CaptureFrame.Format">格式</x:String>
+    <x:String x:Key="String.AddToQueue">加入队列...</x:String>
+    <x:String x:Key="String.AddToQueueTip">将当前片段加入导出队列</x:String>
+    <x:String x:Key="String.BatchExportQueue">批量导出</x:String>
+    <x:String x:Key="String.BatchExportQueueTip">导出队列中的所有片段</x:String>
+    <x:String x:Key="String.BatchExportConfirm">将导出队列中的 {0} 个片段，确认继续？</x:String>
+    <x:String x:Key="String.ExportQueue">导出队列</x:String>
+    <x:String x:Key="String.QueueEmpty">队列为空</x:String>
+    <x:String x:Key="String.ClearQueue">清空队列</x:String>
+    <x:String x:Key="String.Clips">片段</x:String>
+    <x:String x:Key="String.QueueRemove">移除</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -22,6 +22,7 @@
     <x:String x:Key="String.Menu.File">檔案(_F)</x:String>
     <x:String x:Key="String.Menu.OpenVideo">開啟影片(_O)...</x:String>
     <x:String x:Key="String.Menu.SaveClip">儲存片段(_S)...</x:String>
+    <x:String x:Key="String.Menu.ExportQueue">匯出佇列</x:String>
     <x:String x:Key="String.Menu.CloseVideo">關閉影片</x:String>
     <x:String x:Key="String.Menu.Exit">離開(_E)</x:String>
     <x:String x:Key="String.Menu.Tools">工具(_T)</x:String>
@@ -127,4 +128,14 @@
     <x:String x:Key="String.CaptureFrame.CopyToClipboard">複製到剪貼簿</x:String>
     <x:String x:Key="String.CaptureFrame.SaveToFile">儲存到檔案</x:String>
     <x:String x:Key="String.CaptureFrame.Format">格式</x:String>
+    <x:String x:Key="String.AddToQueue">加入佇列...</x:String>
+    <x:String x:Key="String.AddToQueueTip">將目前片段加入匯出佇列</x:String>
+    <x:String x:Key="String.BatchExportQueue">批次匯出</x:String>
+    <x:String x:Key="String.BatchExportQueueTip">匯出佇列中的所有片段</x:String>
+    <x:String x:Key="String.BatchExportConfirm">將匯出佇列中的 {0} 個片段匯出，確認繼續？</x:String>
+    <x:String x:Key="String.ExportQueue">匯出佇列</x:String>
+    <x:String x:Key="String.QueueEmpty">佇列為空</x:String>
+    <x:String x:Key="String.ClearQueue">清空佇列</x:String>
+    <x:String x:Key="String.Clips">片段</x:String>
+    <x:String x:Key="String.QueueRemove">移除</x:String>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Models/ExportQueueItem.cs
+++ b/src/TSCutter.GUI/Models/ExportQueueItem.cs
@@ -1,0 +1,49 @@
+using System;
+using System.IO;
+using CommunityToolkit.Mvvm.ComponentModel;
+using TSCutter.GUI.Utils;
+
+namespace TSCutter.GUI.Models;
+
+public partial class ExportQueueItem : ObservableObject
+{
+    public long QueueItemId { get; init; }
+
+    public string SourceFilePath { get; init; } = "";
+
+    public string OutputFilePath { get; init; } = "";
+
+    public long StartPosition { get; init; }
+
+    public long EndPosition { get; init; }
+
+    public string SourceFileName { get; init; } = "";
+
+    public double StartTimeSeconds { get; init; }
+
+    public double EndTimeSeconds { get; init; }
+
+    public long EstimatedBytes { get; init; }
+
+    [ObservableProperty]
+    private ClipExportStatus _status = ClipExportStatus.Pending;
+
+    public string StatusText => Status switch
+    {
+        ClipExportStatus.Pending => "---",
+        ClipExportStatus.Done => LocalizationManager.Instance.String_Clips_Done,
+        ClipExportStatus.Failed => LocalizationManager.Instance.String_Clips_Failed,
+        _ => "---"
+    };
+
+    public string OutputFileName => Path.GetFileName(OutputFilePath);
+
+    public string StartTimeStr => CommonUtil.FormatSeconds(StartTimeSeconds);
+
+    public string EndTimeStr => CommonUtil.FormatSeconds(EndTimeSeconds);
+
+    public string EstimatedSizeStr => LocalizationManager.Instance.String_SizePrefix
+        + CommonUtil.FormatFileSize(Math.Max(0, EstimatedBytes));
+
+    public string? OutputFilePathStr => OutputFilePath;
+}

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -4,6 +4,7 @@ using System.Collections.ObjectModel;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
@@ -72,6 +73,12 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [ObservableProperty]
     public partial ObservableCollection<PickedClip> Clips { get; set; } = new();
+
+    private long _queueIdCounter;
+    public ObservableCollection<ExportQueueItem> ExportQueue { get; } = new();
+
+    public bool HasExportQueue => ExportQueue.Count > 0;
+    public int ExportQueueCount => ExportQueue.Count;
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(
@@ -701,6 +708,116 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         var sourceName = Path.GetFileNameWithoutExtension(clip.InFileInfo.FullName);
         return $"{sourceName}_clip{clip.ClipID}_({CommonUtil.FormatSeconds(clip.StartTime, true)}-{CommonUtil.FormatSeconds(clip.EndTime, true)}).ts";
+    }
+
+    // ---- 导出队列 ----
+
+    [RelayCommand(CanExecute = nameof(HasSelectedClip))]
+    private async Task AddToQueueAsync()
+    {
+        var defaultName = Path.GetFileNameWithoutExtension(SelectedClip!.InFileInfo.FullName)
+            + $"_({CommonUtil.FormatSeconds(SelectedClip!.StartTime, true)}-{CommonUtil.FormatSeconds(SelectedClip!.EndTime, true)}).ts";
+        var settings = new SaveFileDialogSettings
+        {
+            Title = LocalizationManager.Instance.String_AddToQueue,
+            SuggestedStartLocation = new DesktopDialogStorageFolder(Path.GetDirectoryName(SelectedClip!.InFileInfo.FullName)!),
+            SuggestedFileName = defaultName,
+            Filters = new List<FileFilter>()
+            {
+                new(LocalizationManager.Instance.String_TsFiles, new[] { "ts" }),
+                new(LocalizationManager.Instance.String_AllFiles, "*")
+            },
+            DefaultExtension = "ts"
+        };
+        var result = await _dialogService.ShowSaveFileDialogAsync(this, settings);
+        if (result is null) return;
+
+        var item = new ExportQueueItem
+        {
+            QueueItemId = Interlocked.Increment(ref _queueIdCounter),
+            SourceFilePath = SelectedClip!.InFileInfo.FullName,
+            OutputFilePath = result!.Path!.LocalPath,
+            StartPosition = SelectedClip!.StartPosition,
+            EndPosition = SelectedClip!.EndPosition,
+            SourceFileName = Path.GetFileName(SelectedClip!.InFileInfo.FullName),
+            StartTimeSeconds = SelectedClip!.StartTime,
+            EndTimeSeconds = SelectedClip!.EndTime,
+            EstimatedBytes = Math.Max(0,
+                (SelectedClip!.EndPosition > 0 ? SelectedClip!.EndPosition : SelectedClip!.InFileInfo.Length)
+                - SelectedClip!.StartPosition),
+        };
+        ExportQueue.Add(item);
+        OnPropertyChanged(nameof(HasExportQueue));
+        OnPropertyChanged(nameof(ExportQueueCount));
+        AddToQueueCommand.NotifyCanExecuteChanged();
+        ClearQueueCommand.NotifyCanExecuteChanged();
+        BatchExportQueueCommand.NotifyCanExecuteChanged();
+    }
+
+    [RelayCommand]
+    private void RemoveFromQueue(object? item)
+    {
+        if (item is ExportQueueItem queueItem)
+        {
+            ExportQueue.Remove(queueItem);
+            OnPropertyChanged(nameof(HasExportQueue));
+            OnPropertyChanged(nameof(ExportQueueCount));
+            ClearQueueCommand.NotifyCanExecuteChanged();
+            BatchExportQueueCommand.NotifyCanExecuteChanged();
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(HasExportQueueItems))]
+    private void ClearQueue()
+    {
+        ExportQueue.Clear();
+        OnPropertyChanged(nameof(HasExportQueue));
+        OnPropertyChanged(nameof(ExportQueueCount));
+        ClearQueueCommand.NotifyCanExecuteChanged();
+        BatchExportQueueCommand.NotifyCanExecuteChanged();
+    }
+
+    private bool HasExportQueueItems => ExportQueue.Count > 0;
+
+    [RelayCommand(CanExecute = nameof(HasExportQueueItems))]
+    private async Task BatchExportQueueAsync()
+    {
+        if (ExportQueue.Count == 0) return;
+
+        var confirmMsg = string.Format(
+            LocalizationManager.Instance.String_BatchExportConfirm,
+            ExportQueue.Count);
+        if (!await ShowConfirmAsync(confirmMsg)) return;
+
+        var tasks = ExportQueue.Select(item =>
+            new BatchTask(item.SourceFilePath, item.OutputFilePath, item.StartPosition, item.EndPosition)
+        ).ToList();
+
+        var dialogViewModel = _dialogService.CreateViewModel<OutputWindowViewModel>();
+        dialogViewModel.SetBatchTasks(tasks);
+        await _dialogService.ShowDialogAsync(this, dialogViewModel).ConfigureAwait(true);
+
+        // 更新导出队列中的状态为已完成
+        var completedSet = dialogViewModel.CompletedTaskIndices.ToHashSet();
+        var remaining = new List<ExportQueueItem>();
+        for (int i = 0; i < ExportQueue.Count; i++)
+        {
+            var item = ExportQueue[i];
+            if (completedSet.Contains(i))
+            {
+                item.Status = ClipExportStatus.Done;
+            }
+        }
+        // 从导出队列中移除已完成项
+        for (int i = ExportQueue.Count - 1; i >= 0; i--)
+        {
+            if (ExportQueue[i].Status == ClipExportStatus.Done)
+                ExportQueue.RemoveAt(i);
+        }
+        OnPropertyChanged(nameof(HasExportQueue));
+        OnPropertyChanged(nameof(ExportQueueCount));
+        ClearQueueCommand.NotifyCanExecuteChanged();
+        BatchExportQueueCommand.NotifyCanExecuteChanged();
     }
     
     private void BuildThemeMenuItems()

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -6,6 +6,7 @@
         xmlns:controls="clr-namespace:TSCutter.GUI.Controls"
         xmlns:converters="clr-namespace:TSCutter.GUI.Converters"
         xmlns:local="clr-namespace:TSCutter.GUI"
+        xmlns:models="clr-namespace:TSCutter.GUI.Models"
         xmlns:commonControls="clr-namespace:Classic.CommonControls;assembly=Classic.CommonControls.Avalonia"
         mc:Ignorable="d"
         Width="940" Height="650"
@@ -101,12 +102,14 @@
                         <MenuItem Header="{DynamicResource String.Menu.SaveClip}"
                                   Command="{Binding SaveVideoClickCommand}"
                                   InputGesture="{OnPlatform Ctrl+S, macOS=⌘+S}" />
-                        <MenuItem Header="{DynamicResource String.ExportAll}"
-                                  Command="{Binding ExportAllCommand}" />
+                        <MenuItem Header="{DynamicResource String.AddToQueue}"
+                                  Command="{Binding AddToQueueCommand}" />
+                        <MenuItem Header="{DynamicResource String.Menu.ExportQueue}"
+                                  Command="{Binding BatchExportQueueCommand}" />
                         <Separator />
                         <MenuItem Header="{DynamicResource String.Menu.CloseVideo}"
                                   Command="{Binding CloseVideoClickCommand}"/>
-                        <MenuItem Header="{DynamicResource String.Menu.Exit}" 
+                        <MenuItem Header="{DynamicResource String.Menu.Exit}"
                                   Command="{Binding ExitApplicationCommand}"/>
                     </MenuItem>
                     <MenuItem Header="{DynamicResource String.Menu.Tools}">
@@ -225,100 +228,231 @@
                             <GridSplitter Grid.Column="1" Width="3" />
                             <ClassicBorderDecorator Grid.Column="2" BorderThickness="2" BorderStyle="Sunken">
                                 <DockPanel>
-                                    <!-- Export All button pinned at bottom -->
-                                    <Button DockPanel.Dock="Bottom"
-                                            Command="{Binding ExportAllCommand}"
-                                            HorizontalAlignment="Stretch"
-                                            ToolTip.Tip="{DynamicResource String.ExportAllTip}"
-                                            Margin="0,2,0,0">
-                                        <TextBlock Text="{DynamicResource String.ExportAll}" />
-                                    </Button>
-                                    <Grid>
-                                        <!-- Empty state -->
-                                        <TextBlock Text="{DynamicResource String.Clips.Empty}"
-                                                   HorizontalAlignment="Center"
-                                                   VerticalAlignment="Center"
-                                                   Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
-                                                   IsVisible="{Binding Clips.Count, Converter={x:Static converters:ZeroToVisibilityConverter.Instance}}" />
-                                        <!-- Cards -->
-                                        <ScrollViewer Name="ClipsScrollViewer"
-                                                      HorizontalScrollBarVisibility="Disabled"
-                                                      IsVisible="{Binding Clips.Count, Converter={x:Static converters:PositiveToVisibilityConverter.Instance}}">
-                                            <ItemsControl ItemsSource="{Binding Clips}">
-                                            <ItemsControl.ItemTemplate>
-                                                <DataTemplate>
-                                                    <Border Margin="0,0,0,4"
-                                                            Padding="6"
-                                                            Classes.selected="{Binding IsSelected}"
-                                                            PointerPressed="ClipCard_OnPointerPressed">
-                                                        <Border.Styles>
-                                                            <Style Selector="Border">
-                                                                <Setter Property="Background" Value="Transparent" />
-                                                            </Style>
-                                                            <Style Selector="Border.selected">
-                                                                <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}" />
-                                                            </Style>
-                                                        </Border.Styles>
-                                                        <Grid>
-                                                            <!-- Unselected: Raised border -->
-                                                            <ClassicBorderDecorator BorderThickness="2" BorderStyle="Raised"
-                                                                                    IsVisible="{Binding IsSelected, Converter={x:Static local:App.InverseBoolConverter}}" />
-                                                            <!-- Selected: Sunken border -->
-                                                            <ClassicBorderDecorator BorderThickness="2" BorderStyle="Sunken"
-                                                                                    IsVisible="{Binding IsSelected}" />
-                                                            <!-- Content -->
-                                                            <StackPanel Margin="4" Spacing="2">
-                                                                <!-- Header: ID + Status -->
-                                                                <Grid ColumnDefinitions="Auto,*,Auto">
-                                                                    <TextBlock Text="{Binding ClipID, StringFormat='#{0}'}"
-                                                                               FontWeight="Bold"
-                                                                               FontSize="12" />
-                                                                    <TextBlock Grid.Column="2"
-                                                                               Text="{Binding StatusText}" />
-                                                                </Grid>
-                                                                <!-- Start time -->
-                                                                <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
-                                                                    <TextBlock Text="{DynamicResource String.Table.StartTime}"
-                                                                               Margin="0,0,4,0"
-                                                                               VerticalAlignment="Center" />
-                                                                    <Button Grid.Column="1"
-                                                                            Content="{Binding StartTimeStr}"
-                                                                            Classes="hyperlink"
-                                                                            Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
-                                                                            CommandParameter="{Binding}" />
-                                                                </Grid>
-                                                                <!-- End time -->
-                                                                <Grid ColumnDefinitions="Auto,*">
-                                                                    <TextBlock Text="{DynamicResource String.Table.EndTime}"
-                                                                               Margin="0,0,4,0"
-                                                                               VerticalAlignment="Center" />
-                                                                    <Button Grid.Column="1"
-                                                                            Content="{Binding EndTimeStr}"
-                                                                            Classes="hyperlink"
-                                                                            Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
-                                                                            CommandParameter="{Binding}" />
-                                                                </Grid>
-                                                                <!-- Size + Output Path -->
-                                                                <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
-                                                                    <TextBlock Text="{Binding EstimatedSizeStr}"
-                                                                               VerticalAlignment="Center"
-                                                                               Margin="0,0,8,0" />
-                                                                    <Button Grid.Column="1"
-                                                                            Content="{Binding OutputFilePathStr}"
-                                                                            Classes="hyperlink"
-                                                                            HorizontalContentAlignment="Stretch"
-                                                                            IsVisible="{Binding OutputFileInfo, Converter={x:Static converters:NullToVisibilityConverter.Instance}}"
-                                                                            Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).FindFileCommand}"
-                                                                            CommandParameter="{Binding OutputFileInfo}" />
-                                                                </Grid>
-                                                            </StackPanel>
-                                                        </Grid>
+                                    <!-- TabControl：片段列表和导出队列 -->
+                                    <TabControl Name="RightTabControl">
+                                        <!-- 片段列表 Tab -->
+                                        <TabItem>
+                                            <TabItem.Header>
+                                                <TextBlock>
+                                                    <Run Text="{DynamicResource String.Clips}" />
+                                                </TextBlock>
+                                            </TabItem.Header>
+                                            <DockPanel>
+                                                <Button DockPanel.Dock="Bottom"
+                                                        Command="{Binding ExportAllCommand}"
+                                                        HorizontalAlignment="Stretch"
+                                                        ToolTip.Tip="{DynamicResource String.ExportAllTip}"
+                                                        Margin="0,2,0,0">
+                                                    <TextBlock Text="{DynamicResource String.ExportAll}" />
+                                                </Button>
+                                                <Grid>
+                                                    <!-- Empty state -->
+                                                    <TextBlock Text="{DynamicResource String.Clips.Empty}"
+                                                               HorizontalAlignment="Center"
+                                                               VerticalAlignment="Center"
+                                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                               IsVisible="{Binding Clips.Count, Converter={x:Static converters:ZeroToVisibilityConverter.Instance}}" />
+                                                    <!-- Cards -->
+                                                    <ScrollViewer Name="ClipsScrollViewer"
+                                                                  HorizontalScrollBarVisibility="Disabled"
+                                                                  IsVisible="{Binding Clips.Count, Converter={x:Static converters:PositiveToVisibilityConverter.Instance}}">
+                                                        <ItemsControl ItemsSource="{Binding Clips}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate>
+                                                                <Border Margin="0,0,0,4"
+                                                                        Padding="6"
+                                                                        Classes.selected="{Binding IsSelected}"
+                                                                        PointerPressed="ClipCard_OnPointerPressed">
+                                                                    <Border.Styles>
+                                                                        <Style Selector="Border">
+                                                                            <Setter Property="Background" Value="Transparent" />
+                                                                        </Style>
+                                                                        <Style Selector="Border.selected">
+                                                                            <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}" />
+                                                                        </Style>
+                                                                    </Border.Styles>
+                                                                    <Grid>
+                                                                        <!-- Unselected: Raised border -->
+                                                                        <ClassicBorderDecorator BorderThickness="2" BorderStyle="Raised"
+                                                                                                IsVisible="{Binding IsSelected, Converter={x:Static local:App.InverseBoolConverter}}" />
+                                                                        <!-- Selected: Sunken border -->
+                                                                        <ClassicBorderDecorator BorderThickness="2" BorderStyle="Sunken"
+                                                                                                IsVisible="{Binding IsSelected}" />
+                                                                        <!-- Content -->
+                                                                        <StackPanel Margin="4" Spacing="2">
+                                                                            <!-- Header: ID + Status -->
+                                                                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                                                                <TextBlock Text="{Binding ClipID, StringFormat='#{0}'}"
+                                                                                           FontWeight="Bold"
+                                                                                           FontSize="12" />
+                                                                                <TextBlock Grid.Column="2"
+                                                                                           Text="{Binding StatusText}" />
+                                                                            </Grid>
+                                                                            <!-- Start time -->
+                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                                <TextBlock Text="{DynamicResource String.Table.StartTime}"
+                                                                                           Margin="0,0,4,0"
+                                                                                           VerticalAlignment="Center" />
+                                                                                <Button Grid.Column="1"
+                                                                                        Content="{Binding StartTimeStr}"
+                                                                                        Classes="hyperlink"
+                                                                                        Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
+                                                                                        CommandParameter="{Binding}" />
+                                                                            </Grid>
+                                                                            <!-- End time -->
+                                                                            <Grid ColumnDefinitions="Auto,*">
+                                                                                <TextBlock Text="{DynamicResource String.Table.EndTime}"
+                                                                                           Margin="0,0,4,0"
+                                                                                           VerticalAlignment="Center" />
+                                                                                <Button Grid.Column="1"
+                                                                                        Content="{Binding EndTimeStr}"
+                                                                                        Classes="hyperlink"
+                                                                                        Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
+                                                                                        CommandParameter="{Binding}" />
+                                                                            </Grid>
+                                                                            <!-- Size + Output Path -->
+                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                                <TextBlock Text="{Binding EstimatedSizeStr}"
+                                                                                           VerticalAlignment="Center"
+                                                                                           Margin="0,0,8,0" />
+                                                                                <Button Grid.Column="1"
+                                                                                        Content="{Binding OutputFilePathStr}"
+                                                                                        Classes="hyperlink"
+                                                                                        HorizontalContentAlignment="Stretch"
+                                                                                        IsVisible="{Binding OutputFileInfo, Converter={x:Static converters:NullToVisibilityConverter.Instance}}"
+                                                                                        Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).FindFileCommand}"
+                                                                                        CommandParameter="{Binding OutputFileInfo}" />
+                                                                            </Grid>
+                                                                        </StackPanel>
+                                                                    </Grid>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </ScrollViewer>
+                                                </Grid>
+                                            </DockPanel>
+                                        </TabItem>
+                                        <!-- 导出队列 Tab -->
+                                        <TabItem>
+                                            <TabItem.Header>
+                                                <StackPanel Orientation="Horizontal" Spacing="4">
+                                                    <TextBlock Text="{DynamicResource String.ExportQueue}" />
+                                                    <Border CornerRadius="8"
+                                                            Padding="4,1"
+                                                            MinWidth="18"
+                                                            HorizontalAlignment="Center"
+                                                            BorderBrush="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                            BorderThickness="1"
+                                                            IsVisible="{Binding HasExportQueue}">
+                                                        <TextBlock FontSize="10"
+                                                                   FontWeight="Bold"
+                                                                   HorizontalAlignment="Center"
+                                                                   Text="{Binding ExportQueueCount}" />
                                                     </Border>
-                                                </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                    </ScrollViewer>
-                                </Grid>
+                                                </StackPanel>
+                                            </TabItem.Header>
+                                            <DockPanel>
+                                                <!-- 底部按钮 -->
+                                                <Grid DockPanel.Dock="Bottom"
+                                                      ColumnDefinitions="*,*"
+                                                      ColumnSpacing="4"
+                                                      Margin="0,2,0,0">
+                                                    <Grid.Styles>
+                                                        <Style Selector="Button:disabled Image">
+                                                            <Setter Property="Opacity" Value="0.3" />
+                                                        </Style>
+                                                    </Grid.Styles>
+                                                    <Button Grid.Column="0"
+                                                            Command="{Binding ClearQueueCommand}">
+                                                        <TextBlock Text="{DynamicResource String.ClearQueue}" />
+                                                    </Button>
+                                                    <Button Grid.Column="1"
+                                                            Command="{Binding BatchExportQueueCommand}"
+                                                            Classes="accent">
+                                                        <StackPanel Orientation="Horizontal" HorizontalAlignment="Center">
+                                                            <Image Height="16" Source="/Assets/save.gif" />
+                                                            <TextBlock VerticalAlignment="Center"
+                                                                       Text="{DynamicResource String.BatchExportQueue}"
+                                                                       Margin="4,0,0,0" />
+                                                        </StackPanel>
+                                                    </Button>
+                                                </Grid>
+                                                <Grid>
+                                                    <!-- Empty state -->
+                                                    <TextBlock Text="{DynamicResource String.QueueEmpty}"
+                                                               HorizontalAlignment="Center"
+                                                               VerticalAlignment="Center"
+                                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                                                               IsVisible="{Binding HasExportQueue, Converter={x:Static local:App.InverseBoolConverter}}" />
+                                                    <!-- Queue cards -->
+                                                    <ScrollViewer HorizontalScrollBarVisibility="Disabled"
+                                                                  IsVisible="{Binding HasExportQueue}">
+                                                        <ItemsControl ItemsSource="{Binding ExportQueue}">
+                                                        <ItemsControl.ItemTemplate>
+                                                            <DataTemplate x:DataType="models:ExportQueueItem">
+                                                                <Border Margin="0,0,0,4"
+                                                                        Padding="6">
+                                                                    <Border.Styles>
+                                                                        <Style Selector="Border">
+                                                                            <Setter Property="Background" Value="Transparent" />
+                                                                        </Style>
+                                                                    </Border.Styles>
+                                                                    <Grid>
+                                                                        <ClassicBorderDecorator BorderThickness="2" BorderStyle="Raised" />
+                                                                        <Grid ColumnDefinitions="*,Auto">
+                                                                        <StackPanel Grid.Column="0" Margin="4" Spacing="2">
+                                                                            <!-- Header: Source filename -->
+                                                                            <TextBlock Text="{Binding SourceFileName}"
+                                                                                       TextTrimming="CharacterEllipsis"
+                                                                                       FontWeight="Bold"
+                                                                                       FontSize="12" />
+                                                                            <!-- Start time -->
+                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                                <TextBlock Text="{DynamicResource String.Table.StartTime}"
+                                                                                           Margin="0,0,4,0"
+                                                                                           VerticalAlignment="Center" />
+                                                                                <TextBlock Grid.Column="1"
+                                                                                           Text="{Binding StartTimeStr}" />
+                                                                            </Grid>
+                                                                            <!-- End time -->
+                                                                            <Grid ColumnDefinitions="Auto,*">
+                                                                                <TextBlock Text="{DynamicResource String.Table.EndTime}"
+                                                                                           Margin="0,0,4,0"
+                                                                                           VerticalAlignment="Center" />
+                                                                                <TextBlock Grid.Column="1"
+                                                                                           Text="{Binding EndTimeStr}" />
+                                                                            </Grid>
+                                                                            <!-- Size + Output path -->
+                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                                <TextBlock Text="{Binding EstimatedSizeStr}"
+                                                                                           VerticalAlignment="Center"
+                                                                                           Margin="0,0,8,0" />
+                                                                                <TextBlock Grid.Column="1"
+                                                                                           Text="{Binding OutputFilePathStr}"
+                                                                                           TextTrimming="CharacterEllipsis" />
+                                                                            </Grid>
+                                                                        </StackPanel>
+                                                                        <!-- 关闭按钮 × -->
+                                                                        <TextBlock Grid.Column="1"
+                                                                                   Text="×"
+                                                                                   FontSize="14"
+                                                                                   VerticalAlignment="Top"
+                                                                                   Margin="0,2,4,0"
+                                                                                   Cursor="Hand"
+                                                                                   PointerPressed="QueueRemove_OnPointerPressed"
+                                                                                   ToolTip.Tip="{DynamicResource String.QueueRemove}" />
+                                                                        </Grid>
+                                                                    </Grid>
+                                                                </Border>
+                                                            </DataTemplate>
+                                                        </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                    </ScrollViewer>
+                                                </Grid>
+                                            </DockPanel>
+                                        </TabItem>
+                                    </TabControl>
                                 </DockPanel>
                             </ClassicBorderDecorator>
                         </Grid>

--- a/src/TSCutter.GUI/Views/MainWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml.cs
@@ -59,6 +59,14 @@ public partial class MainWindow : ClassicWindow
         }
     }
 
+    private void QueueRemove_OnPointerPressed(object? sender, PointerPressedEventArgs e)
+    {
+        if (sender is TextBlock { DataContext: ExportQueueItem item })
+        {
+            ViewModel.RemoveFromQueueCommand.Execute(item);
+        }
+    }
+
     private async void CustomSlider_OnValueChangedAfterMouseUp(object? sender, double e)
     {
         if (!ViewModel.IsVideoInitialized) return;


### PR DESCRIPTION
**Description:**
This PR introduces an export queue that allows users to defer clip exporting and batch-process them later across multiple files.

**Key changes:**
- Add `ExportQueueItem` model to accumulate export tasks independently from the current video
- Replace the right-side panel with a `TabControl` (Clips / Export Queue tabs), the queue tab shows a task count badge
- "Save Clip" button behavior remains unchanged — immediate export as before
- Add "Add to Queue" menu item that opens the save dialog and enqueues the task without blocking
- Add "Export Queue" menu item to batch-process all queued tasks sequentially
- Support clearing queue and removing individual items via the `×` button
- Add localization strings for zh-CN, en-US, zh-TW

---

**内容：**
此 PR 引入了导出队列功能，用户可以将剪辑任务先加入队列，之后再统一批量导出，期间可以自由切换文件继续剪辑。

**主要改动：**
- 新增 `ExportQueueItem` 模型，独立于当前视频累积导出任务
- 右侧面板改为 `TabControl`（片段列表 / 导出队列），队列 Tab 显示任务计数角标
- "保存片段"按钮行为完全不变，点击立即导出
- 新增菜单"加入队列"，弹出保存对话框后入队，不阻塞操作
- 新增菜单"导出队列"，依次处理队列中的所有导出任务
- 支持清空队列和通过 `×` 按钮单独移除队列项
- 新增 zh-CN / en-US / zh-TW 多语言字符串