### PR TITLE
Fix raw cutter dropping the final byte in packet mode

### DIFF
--- a/src/TSCutter.GUI/App.axaml.cs
+++ b/src/TSCutter.GUI/App.axaml.cs
@@ -19,7 +19,7 @@ namespace TSCutter.GUI;
 
 public partial class App : Application
 {
-    public const string CurrentTag = "alphabuild_20260619";
+    public const string CurrentTag = "alphabuild_20260714";
     public override void Initialize()
     {
         AvaloniaXamlLoader.Load(this);

--- a/src/TSCutter.GUI/TSCutter.GUI.csproj
+++ b/src/TSCutter.GUI/TSCutter.GUI.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <AssemblyName>TSCutterGUI</AssemblyName>
-        <Version>0.0.3.3</Version>
+        <Version>0.0.3.4</Version>
         <OutputType>WinExe</OutputType>
         <ApplicationIcon>Assets/logo.ico</ApplicationIcon>
         <TargetFramework>net10.0</TargetFramework>

--- a/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
@@ -257,17 +257,20 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
                 return;
             }
             startPos = TsUtil.PacketToOffset(StartPacket, SyncOffset);
-            endPos = Math.Min(TsUtil.PacketToOffset(EndPacket + 1, SyncOffset) - 1, FileSize - 1);
+            // CopyFileAsync interprets its end position as exclusive.  The next packet
+            // boundary therefore includes all 188 bytes of EndPacket.
+            endPos = Math.Min(TsUtil.PacketToOffset(EndPacket + 1, SyncOffset), FileSize);
             defaultNameSuffix = $"{StartPacket}-{EndPacket}";
         }
         else
         {
             startPos = Math.Max(0, StartOffset);
-            endPos = Math.Min(Math.Max(startPos, EndOffset), FileSize - 1);
-            defaultNameSuffix = $"{startPos}-{endPos}";
+            var endOffset = Math.Min(Math.Max(startPos, EndOffset), FileSize - 1);
+            endPos = endOffset + 1;
+            defaultNameSuffix = $"{startPos}-{endOffset}";
         }
 
-        if (startPos >= endPos || endPos >= FileSize)
+        if (startPos >= endPos || endPos > FileSize)
         {
             await ShowMessageAsync(
                 LocalizationManager.Instance.String_RawCutter_InvalidRange,

--- a/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
@@ -112,6 +112,18 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
             if (_syncingSlider) return;
             var v = (long)Math.Round(value);
             v = Math.Clamp(v, SyncOffset, Math.Max(SyncOffset, FileSize - 1));
+
+            if (IsPacketMode)
+            {
+                var packet = Math.Min(OffsetToPacketIndex(v), EndPacket);
+                v = TsUtil.PacketToOffset(packet, SyncOffset);
+                _syncingSlider = true;
+                StartPacket = packet;
+                StartOffset = v;
+                _syncingSlider = false;
+                return;
+            }
+
             if (v > SliderEnd) v = (long)SliderEnd;
             _syncingSlider = true;
             StartOffset = v;
@@ -131,6 +143,18 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
             if (_syncingSlider) return;
             var v = (long)Math.Round(value);
             v = Math.Clamp(v, SyncOffset, Math.Max(SyncOffset, FileSize - 1));
+
+            if (IsPacketMode)
+            {
+                var packet = Math.Max(OffsetToPacketIndex(v), StartPacket);
+                v = PacketEndOffset(packet);
+                _syncingSlider = true;
+                EndPacket = packet;
+                EndOffset = v;
+                _syncingSlider = false;
+                return;
+            }
+
             if (v < SliderStart) v = (long)SliderStart;
             _syncingSlider = true;
             EndOffset = v;
@@ -194,7 +218,7 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
 
         EndPacket = Math.Max(0, TotalPackets - 1);
         StartOffset = TsUtil.PacketToOffset(StartPacket, SyncOffset);
-        EndOffset = FileSize - 1;
+        EndOffset = PacketEndOffset(EndPacket);
     }
 
     partial void OnStartPacketChanged(long value)
@@ -215,12 +239,38 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
 
     partial void OnIsPacketModeChanged(bool value)
     {
+        if (value && TotalPackets > 0)
+        {
+            var startPacket = OffsetToPacketIndex(StartOffset);
+            var endPacket = Math.Max(startPacket, OffsetToPacketIndex(EndOffset));
+
+            _syncingSlider = true;
+            StartPacket = startPacket;
+            EndPacket = endPacket;
+            StartOffset = TsUtil.PacketToOffset(startPacket, SyncOffset);
+            EndOffset = PacketEndOffset(endPacket);
+            _syncingSlider = false;
+        }
+
         // 切换模式时强制刷新
         OnPropertyChanged(nameof(RangeInfoStr));
         OnPropertyChanged(nameof(SliderStart));
         OnPropertyChanged(nameof(SliderEnd));
         OnPropertyChanged(nameof(PacketMax));
         OnPropertyChanged(nameof(OffsetMax));
+    }
+
+    private long OffsetToPacketIndex(long offset)
+    {
+        return Math.Clamp(
+            (offset - SyncOffset) / TsUtil.TsPacketSize,
+            0,
+            Math.Max(0, TotalPackets - 1));
+    }
+
+    private long PacketEndOffset(long packetIndex)
+    {
+        return Math.Min(TsUtil.PacketToOffset(packetIndex + 1, SyncOffset) - 1, FileSize - 1);
     }
 
     [RelayCommand]


### PR DESCRIPTION
## Summary

Fix an off-by-one error in the raw cutter when cutting TS packets.

The UI calculated an inclusive end byte while the underlying copy operation treats its end position as exclusive. As a result:

- Cutting one TS packet produced 187 bytes instead of 188 bytes.
- Cutting N consecutive packets produced `N × 188 - 1` bytes.

Packet mode now uses the next packet boundary as the exclusive copy end position, ensuring every selected TS packet is copied in full.

This also aligns offset-mode and end-of-file boundary handling, and bumps the embedded version to `0.0.3.4`.

## Validation

- `dotnet build src/TSCutter.GUI.sln --no-restore`
- Build succeeded with 0 errors.
---

## 修复内容

修复原始剪切器按 TS 包切割时，每次输出少 1 字节的问题。

此前界面按“包含结束字节”计算范围，而底层复制逻辑将结束位置视为排他边界，导致：

- 选择 1 个 TS 包时输出 187 字节，而非 188 字节
- 选择 N 个连续包时输出 `N × 188 - 1` 字节

现统一为排他结束位置：按包模式使用下一包的起始偏移作为复制终点，确保所选 TS 包完整输出。

同时修正偏移模式与文件末尾的边界处理，并更新内置版本至 `0.0.3.4`。

## 验证

- `dotnet build src/TSCutter.GUI.sln --no-restore`
- 构建成功（0 errors）