### PR TITLE
Fix automatic language detection in macOS app bundles

### DIFF
--- a/src/TSCutter.GUI/App.axaml.cs
+++ b/src/TSCutter.GUI/App.axaml.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
@@ -60,9 +59,6 @@ public partial class App : Application
             AppConfig.IsSystemDarkMode = true;
         }
         
-        // 记录系统当前本地化名称
-        AppConfig.SystemLocName = Thread.CurrentThread.CurrentUICulture.Name;
-
         // 加载配置
         var configService = Locator.Current.GetService<IConfigurationService>()!;
         configService.Load();

--- a/src/TSCutter.GUI/Models/AppConfig.cs
+++ b/src/TSCutter.GUI/Models/AppConfig.cs
@@ -8,10 +8,6 @@ public class AppConfig
     // 系统当前是否处于深色模式
     [JsonIgnore]
     public static bool IsSystemDarkMode { get; set; }
-    // 系统当前是否处于深色模式
-    [JsonIgnore]
-    public static string SystemLocName { get; set; }
-
     [JsonIgnore]
     public ThemeModel ThemeModel => ThemeModel.AllThemes.FirstOrDefault(x => x.Name == ThemeName)!;
     [JsonIgnore]

--- a/src/TSCutter.GUI/Services/ConfigurationService.cs
+++ b/src/TSCutter.GUI/Services/ConfigurationService.cs
@@ -1,7 +1,10 @@
 using System;
+using System.Collections.Generic;
+using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text.Json;
 using System.Threading;
 using Avalonia;
@@ -125,13 +128,91 @@ public class ConfigurationService : IConfigurationService
 
     private static string AutoDetectLanguage()
     {
-        var currLoc = AppConfig.SystemLocName;
-        var loc = currLoc switch
+        foreach (var languageName in GetPreferredLanguageNames())
         {
-            "zh-CN" or "zh-SG" => "zh-CN",
-            _ when currLoc.StartsWith("zh-") => "zh-TW",
-            _ => "en-US"
-        };
-        return loc;
+            var language = ResolveLanguageName(languageName);
+            if (language != null)
+                return language;
+        }
+
+        return "en-US";
+    }
+
+    private static string? ResolveLanguageName(string? languageName)
+    {
+        if (string.IsNullOrWhiteSpace(languageName))
+            return null;
+
+        var normalized = NormalizeLanguageName(languageName);
+        if (normalized.StartsWith("zh-Hant", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Contains("-TW", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Contains("-HK", StringComparison.OrdinalIgnoreCase) ||
+            normalized.Contains("-MO", StringComparison.OrdinalIgnoreCase))
+            return "zh-TW";
+
+        if (normalized.StartsWith("zh", StringComparison.OrdinalIgnoreCase))
+            return "zh-CN";
+
+        return normalized.StartsWith("en", StringComparison.OrdinalIgnoreCase)
+            ? "en-US"
+            : null;
+    }
+
+    private static IEnumerable<string> GetPreferredLanguageNames()
+    {
+        if (OperatingSystem.IsMacOS())
+        {
+            foreach (var languageName in ReadMacOSAppleLanguages())
+                yield return languageName;
+        }
+
+        yield return CultureInfo.CurrentUICulture.Name;
+        yield return CultureInfo.CurrentCulture.Name;
+
+        foreach (var variable in new[] { "LC_ALL", "LC_MESSAGES", "LANG" })
+            yield return Environment.GetEnvironmentVariable(variable) ?? string.Empty;
+    }
+
+    [SupportedOSPlatform("macos")]
+    private static IReadOnlyList<string> ReadMacOSAppleLanguages()
+    {
+        try
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "/usr/bin/defaults",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+            startInfo.ArgumentList.Add("read");
+            startInfo.ArgumentList.Add("-g");
+            startInfo.ArgumentList.Add("AppleLanguages");
+
+            using var process = Process.Start(startInfo);
+            if (process == null || !process.WaitForExit(1000))
+                return [];
+
+            var languageNames = new List<string>();
+            foreach (var line in process.StandardOutput.ReadToEnd().Split('\n'))
+            {
+                var languageName = line.Trim().Trim(',', '"');
+                if (languageName.Length > 0 && languageName is not "(" and not ")")
+                    languageNames.Add(languageName);
+            }
+
+            return languageNames;
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private static string NormalizeLanguageName(string languageName)
+    {
+        var normalized = languageName.Trim().Trim('"').Replace('_', '-');
+        var dotIndex = normalized.IndexOf('.', StringComparison.Ordinal);
+        return dotIndex >= 0 ? normalized[..dotIndex] : normalized;
     }
 }


### PR DESCRIPTION
## Changes
- Read the macOS `AppleLanguages` preference before falling back to .NET cultures.
- Support `zh-Hans-*`, `zh-Hant-*`, and Taiwan, Hong Kong, and Macau language tags.
- Keep .NET culture and `LC_*` / `LANG` environment variables as fallback sources.
- Remove the old detection path that relied only on the startup thread culture.

## Verification
- `dotnet build src/TSCutter.GUI.sln --no-restore`
- Built an osx-arm64 .app using the GitHub Actions packaging flow and manually verified language detection.

---

## 变更内容
- macOS 下优先读取系统 `AppleLanguages` 偏好设置。
- 支持 `zh-Hans-*`、`zh-Hant-*` 及台湾、香港、澳门等语言标签。
- 保留 .NET culture 与 `LC_*` / `LANG` 作为回退识别来源。
- 移除仅依赖启动线程 culture 的旧识别方式。

## 验证
- `dotnet build src/TSCutter.GUI.sln --no-restore`
- 按 Actions 的 osx-arm64 发布流程生成 .app，并手动验证语言识别通过。