### PR TITLE
Refine the dark theme palette and visual hierarchy

### DIFF
--- a/src/TSCutter.GUI/Controls/CustomSliderResources.axaml
+++ b/src/TSCutter.GUI/Controls/CustomSliderResources.axaml
@@ -32,13 +32,13 @@
             <system:Double x:Key="SliderInnerThumbWidth">0</system:Double>
             <CornerRadius x:Key="SliderThumbCornerRadius">0</CornerRadius>
             <CornerRadius x:Key="SliderTrackCornerRadius">0</CornerRadius>
-            <SolidColorBrush x:Key="SliderThumbBorderBrush" Color="#0091f8" />
-            <SolidColorBrush x:Key="SliderTrackValueFill" Opacity="0.2" Color="#717174" />
-            <SolidColorBrush x:Key="SliderTrackValueFillPointerOver" Opacity="0.2" Color="#717174" />
-            <SolidColorBrush x:Key="SliderTrackValueFillPressed" Opacity="0.2" Color="#717174" />
-            <SolidColorBrush x:Key="SliderTrackFill" Opacity="0.2" Color="#717174" />
-            <SolidColorBrush x:Key="SliderTrackFillPointerOver" Opacity="0.2" Color="#717174" />
-            <SolidColorBrush x:Key="SliderTrackFillPressed" Opacity="0.2" Color="#717174" />
+            <SolidColorBrush x:Key="SliderThumbBorderBrush" Color="#4F8FD8" />
+            <SolidColorBrush x:Key="SliderTrackValueFill" Opacity="0.24" Color="#7C8592" />
+            <SolidColorBrush x:Key="SliderTrackValueFillPointerOver" Opacity="0.3" Color="#87919E" />
+            <SolidColorBrush x:Key="SliderTrackValueFillPressed" Opacity="0.34" Color="#929CA9" />
+            <SolidColorBrush x:Key="SliderTrackFill" Opacity="0.24" Color="#7C8592" />
+            <SolidColorBrush x:Key="SliderTrackFillPointerOver" Opacity="0.3" Color="#87919E" />
+            <SolidColorBrush x:Key="SliderTrackFillPressed" Opacity="0.34" Color="#929CA9" />
         </ResourceDictionary>
     </ResourceDictionary.ThemeDictionaries>
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Themes/DarkStandardWindows.axaml
+++ b/src/TSCutter.GUI/Themes/DarkStandardWindows.axaml
@@ -2,36 +2,67 @@
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                     xmlns:common="clr-namespace:Classic.CommonControls;assembly=Classic.CommonControls.Avalonia"
                     xmlns:system="clr-namespace:System;assembly=netstandard">
-    <Color x:Key="{x:Static common:SystemColors.ActiveBorderColorKey}">#ff2a2a2a</Color>
-    <Color x:Key="{x:Static common:SystemColors.ActiveCaptionColorKey}">#ff1a2630</Color>
-    <Color x:Key="{x:Static common:SystemColors.ActiveCaptionTextColorKey}">#ffe8e8e8</Color>
-    <Color x:Key="{x:Static common:SystemColors.AppWorkspaceColorKey}">#ff1c1c1c</Color>
-    <Color x:Key="{x:Static common:SystemColors.ControlColorKey}">#ff363636</Color>
-    <Color x:Key="{x:Static common:SystemColors.ControlDarkColorKey}">#ff2c2c2c</Color>
-    <Color x:Key="{x:Static common:SystemColors.ControlDarkDarkColorKey}">#ff1f1f1f</Color>
-    <Color x:Key="{x:Static common:SystemColors.ControlLightColorKey}">#ff505050</Color>
-    <Color x:Key="{x:Static common:SystemColors.ControlLightLightColorKey}">#ff6e6e6e</Color>
-    <Color x:Key="{x:Static common:SystemColors.ControlTextColorKey}">#ffe8e8e8</Color>
-    <Color x:Key="{x:Static common:SystemColors.DesktopColorKey}">#ff181818</Color>
-    <Color x:Key="{x:Static common:SystemColors.GradientActiveCaptionColorKey}">#ff2c4a70</Color>
-    <Color x:Key="{x:Static common:SystemColors.GradientInactiveCaptionColorKey}">#ff3c3c3c</Color>
-    <Color x:Key="{x:Static common:SystemColors.GrayTextColorKey}">#ff888888</Color>
-    <Color x:Key="{x:Static common:SystemColors.HighlightColorKey}">#ff3a5f8a</Color>
-    <Color x:Key="{x:Static common:SystemColors.HighlightTextColorKey}">#fff0f0f0</Color>
-    <Color x:Key="{x:Static common:SystemColors.HotTrackColorKey}">#ff5073a0</Color>
-    <Color x:Key="{x:Static common:SystemColors.InactiveBorderColorKey}">#ff2a2a2a</Color>
-    <Color x:Key="{x:Static common:SystemColors.InactiveCaptionColorKey}">#ff282828</Color>
-    <Color x:Key="{x:Static common:SystemColors.InactiveCaptionTextColorKey}">#ff969696</Color>
-    <Color x:Key="{x:Static common:SystemColors.InfoColorKey}">#ff2e2e2e</Color>
-    <Color x:Key="{x:Static common:SystemColors.InfoTextColorKey}">#ffe8e8e8</Color>
-    <Color x:Key="{x:Static common:SystemColors.MenuColorKey}">#ff2a2a2a</Color>
-    <Color x:Key="{x:Static common:SystemColors.MenuBarColorKey}">#ff282828</Color>
-    <Color x:Key="{x:Static common:SystemColors.MenuHighlightColorKey}">#ff3a6fa5</Color>
-    <Color x:Key="{x:Static common:SystemColors.MenuTextColorKey}">#ffe8e8e8</Color>
-    <Color x:Key="{x:Static common:SystemColors.ScrollBarColorKey}">#ff363636</Color>
-    <Color x:Key="{x:Static common:SystemColors.WindowColorKey}">#ff1c1c1c</Color>
-    <Color x:Key="{x:Static common:SystemColors.WindowFrameColorKey}">#ff2a2a2a</Color>
-    <Color x:Key="{x:Static common:SystemColors.WindowTextColorKey}">#ffe8e8e8</Color>
+    <!-- 深色主题使用带少量蓝相的中性灰。经典凹凸边框仍保留四级明暗，但降低最亮边缘的反差。 -->
+    <Color x:Key="{x:Static common:SystemColors.ActiveBorderColorKey}">#ff3a414a</Color>
+    <Color x:Key="{x:Static common:SystemColors.ActiveCaptionColorKey}">#ff243448</Color>
+    <Color x:Key="{x:Static common:SystemColors.ActiveCaptionTextColorKey}">#fff2f4f7</Color>
+    <Color x:Key="{x:Static common:SystemColors.AppWorkspaceColorKey}">#ff15171a</Color>
+    <Color x:Key="{x:Static common:SystemColors.ControlColorKey}">#ff292d33</Color>
+    <Color x:Key="{x:Static common:SystemColors.ControlDarkColorKey}">#ff20242a</Color>
+    <Color x:Key="{x:Static common:SystemColors.ControlDarkDarkColorKey}">#ff121418</Color>
+    <Color x:Key="{x:Static common:SystemColors.ControlLightColorKey}">#ff373e47</Color>
+    <Color x:Key="{x:Static common:SystemColors.ControlLightLightColorKey}">#ff48515c</Color>
+    <Color x:Key="{x:Static common:SystemColors.ControlTextColorKey}">#ffe6e9ee</Color>
+    <Color x:Key="{x:Static common:SystemColors.DesktopColorKey}">#ff111316</Color>
+    <Color x:Key="{x:Static common:SystemColors.GradientActiveCaptionColorKey}">#ff2d5275</Color>
+    <Color x:Key="{x:Static common:SystemColors.GradientInactiveCaptionColorKey}">#ff30353d</Color>
+    <Color x:Key="{x:Static common:SystemColors.GrayTextColorKey}">#ff929aa6</Color>
+    <Color x:Key="{x:Static common:SystemColors.HighlightColorKey}">#ff386c9e</Color>
+    <Color x:Key="{x:Static common:SystemColors.HighlightTextColorKey}">#fff7f9fb</Color>
+    <Color x:Key="{x:Static common:SystemColors.HotTrackColorKey}">#ff68a0db</Color>
+    <Color x:Key="{x:Static common:SystemColors.InactiveBorderColorKey}">#ff30353d</Color>
+    <Color x:Key="{x:Static common:SystemColors.InactiveCaptionColorKey}">#ff24282e</Color>
+    <Color x:Key="{x:Static common:SystemColors.InactiveCaptionTextColorKey}">#ff9da5b1</Color>
+    <Color x:Key="{x:Static common:SystemColors.InfoColorKey}">#ff24282e</Color>
+    <Color x:Key="{x:Static common:SystemColors.InfoTextColorKey}">#ffe6e9ee</Color>
+    <Color x:Key="{x:Static common:SystemColors.MenuColorKey}">#ff24282e</Color>
+    <Color x:Key="{x:Static common:SystemColors.MenuBarColorKey}">#ff202329</Color>
+    <Color x:Key="{x:Static common:SystemColors.MenuHighlightColorKey}">#ff386c9e</Color>
+    <Color x:Key="{x:Static common:SystemColors.MenuTextColorKey}">#ffe6e9ee</Color>
+    <Color x:Key="{x:Static common:SystemColors.ScrollBarColorKey}">#ff292d33</Color>
+    <Color x:Key="{x:Static common:SystemColors.WindowColorKey}">#ff181a1e</Color>
+    <Color x:Key="{x:Static common:SystemColors.WindowFrameColorKey}">#ff111316</Color>
+    <Color x:Key="{x:Static common:SystemColors.WindowTextColorKey}">#ffe6e9ee</Color>
+
+    <!-- 应用语义色统一菜单、表格和状态提示，避免各窗口分别定义近似颜色。 -->
+    <Color x:Key="AppAccentColor">#ff4f8fd8</Color>
+    <Color x:Key="AppAccentHoverColor">#ff68a0db</Color>
+    <Color x:Key="AppSelectionColor">#ff315f91</Color>
+    <Color x:Key="AppSurfaceRaisedColor">#ff292d33</Color>
+    <Color x:Key="AppSurfaceHoverColor">#ff333943</Color>
+    <Color x:Key="AppBorderColor">#ff3c424b</Color>
+    <Color x:Key="AppSecondaryTextColor">#ffaab1bc</Color>
+    <Color x:Key="AppErrorColor">#ffff7070</Color>
+    <Color x:Key="AppWarningColor">#ffe6b84a</Color>
+    <Color x:Key="AppSuccessColor">#ff72c985</Color>
+
+    <SolidColorBrush x:Key="AppAccentBrush" Color="{DynamicResource AppAccentColor}" />
+    <SolidColorBrush x:Key="AppAccentHoverBrush" Color="{DynamicResource AppAccentHoverColor}" />
+    <SolidColorBrush x:Key="AppSelectionBrush" Color="{DynamicResource AppSelectionColor}" />
+    <SolidColorBrush x:Key="AppSurfaceRaisedBrush" Color="{DynamicResource AppSurfaceRaisedColor}" />
+    <SolidColorBrush x:Key="AppSurfaceHoverBrush" Color="{DynamicResource AppSurfaceHoverColor}" />
+    <SolidColorBrush x:Key="AppBorderBrush" Color="{DynamicResource AppBorderColor}" />
+    <SolidColorBrush x:Key="AppSecondaryTextBrush" Color="{DynamicResource AppSecondaryTextColor}" />
+    <SolidColorBrush x:Key="AppErrorBrush" Color="{DynamicResource AppErrorColor}" />
+    <SolidColorBrush x:Key="AppWarningBrush" Color="{DynamicResource AppWarningColor}" />
+    <SolidColorBrush x:Key="AppSuccessBrush" Color="{DynamicResource AppSuccessColor}" />
+
+    <!-- 兼容项目中使用的 Fluent 资源名，让空状态、只读输入框和选中卡片跟随新色板。 -->
+    <Color x:Key="SystemAccentColor">#ff4f8fd8</Color>
+    <Color x:Key="SystemAccentColorLight1">#ff315f91</Color>
+    <Color x:Key="SystemBaseLowColor">#ff343a43</Color>
+    <SolidColorBrush x:Key="SystemControlForegroundBaseMediumBrush" Color="#ffaab1bc" />
+    <SolidColorBrush x:Key="SystemControlBackgroundBaseLowBrush" Color="#ff20242a" />
 
     <system:Double x:Key="{x:Static common:SystemParameters.HorizontalScrollBarHeightKey}">16</system:Double>
     <system:Double x:Key="{x:Static common:SystemParameters.VerticalScrollBarWidthKey}">16</system:Double>
@@ -49,5 +80,24 @@
     <system:Double x:Key="FontSizeLarge">13</system:Double>
     
     <SolidColorBrush x:Key="ThemeForegroundBrush" Color="{DynamicResource {x:Static common:SystemColors.ControlTextColorKey}}" />
-    <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="{DynamicResource {x:Static common:SystemColors.ControlTextColorKey}}" />
+
+    <!-- 表格减少高亮蓝块和亮网格线的冲突，同时明确表头、悬停、选中和焦点层级。 -->
+    <SolidColorBrush x:Key="DataGridCellBackgroundBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="DataGridRowBackgroundBrush" Color="Transparent" />
+    <SolidColorBrush x:Key="DataGridGridLinesBrush" Color="#ff343b44" />
+    <SolidColorBrush x:Key="DataGridFillerColumnGridLinesBrush" Color="#ff343b44" />
+    <SolidColorBrush x:Key="DataGridColumnHeaderBackgroundBrush" Color="#ff292d33" />
+    <SolidColorBrush x:Key="DataGridColumnHeaderForegroundBrush" Color="#ffe6e9ee" />
+    <SolidColorBrush x:Key="DataGridColumnHeaderHoveredBackgroundBrush" Color="#ff333943" />
+    <SolidColorBrush x:Key="DataGridColumnHeaderPressedBackgroundBrush" Color="#ff20242a" />
+    <SolidColorBrush x:Key="DataGridColumnHeaderDraggedBackgroundBrush" Color="#ff333943" />
+    <SolidColorBrush x:Key="DataGridRowHoveredBackgroundColor" Color="#ff252a31" />
+    <SolidColorBrush x:Key="DataGridRowSelectedBackgroundBrush" Color="#ff315f91" />
+    <SolidColorBrush x:Key="DataGridRowSelectedHoveredBackgroundBrush" Color="#ff3b6e9f" />
+    <SolidColorBrush x:Key="DataGridRowSelectedUnfocusedBackgroundBrush" Color="#ff2b4a67" />
+    <SolidColorBrush x:Key="DataGridRowSelectedHoveredUnfocusedBackgroundBrush" Color="#ff345875" />
+    <SolidColorBrush x:Key="DataGridCellFocusVisualPrimaryBrush" Color="#ff72a7e0" />
+    <SolidColorBrush x:Key="DataGridCellFocusVisualSecondaryBrush" Color="#ff181a1e" />
+    <SolidColorBrush x:Key="DataGridCellInvalidBrush" Color="#ffff7070" />
+    <SolidColorBrush x:Key="DataGridRowInvalidBrush" Color="#33ff7070" />
 </ResourceDictionary>

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -76,9 +76,13 @@
                 <ResourceDictionary.ThemeDictionaries>
                     <ResourceDictionary x:Key="Light">
                         <SolidColorBrush x:Key="MaskBackgroundBrush">White</SolidColorBrush>
+                        <SolidColorBrush x:Key="ClipSelectionBackgroundBrush"
+                                         Color="{DynamicResource SystemAccentColorLight1}" />
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="Dark">
-                        <SolidColorBrush x:Key="MaskBackgroundBrush">Black</SolidColorBrush>
+                        <SolidColorBrush x:Key="MaskBackgroundBrush" Color="#111316" />
+                        <!-- 选中卡片只做轻微蓝色染色，避免与标题栏、进度条争夺视觉焦点。 -->
+                        <SolidColorBrush x:Key="ClipSelectionBackgroundBrush" Color="#2B3B4B" />
                     </ResourceDictionary>
                 </ResourceDictionary.ThemeDictionaries>
             </ResourceDictionary>
@@ -272,7 +276,7 @@
                                                                             <Setter Property="Background" Value="Transparent" />
                                                                         </Style>
                                                                         <Style Selector="Border.selected">
-                                                                            <Setter Property="Background" Value="{DynamicResource SystemAccentColorLight1}" />
+                                                                            <Setter Property="Background" Value="{DynamicResource ClipSelectionBackgroundBrush}" />
                                                                         </Style>
                                                                     </Border.Styles>
                                                                     <Grid>

--- a/src/TSCutter.GUI/Views/TsCheckWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsCheckWindow.axaml
@@ -26,12 +26,12 @@
                     <SolidColorBrush x:Key="TsCheckPacketShareBrush" Color="#2E6FAD" />
                 </ResourceDictionary>
                 <ResourceDictionary x:Key="Dark">
-                    <SolidColorBrush x:Key="TsCheckErrorCellBackgroundBrush" Color="#FF5252" Opacity="0.16" />
-                    <SolidColorBrush x:Key="TsCheckErrorCellForegroundBrush" Color="#FF7A7A" />
-                    <SolidColorBrush x:Key="TsCheckWarningCellBackgroundBrush" Color="#FFC107" Opacity="0.14" />
-                    <SolidColorBrush x:Key="TsCheckWarningCellForegroundBrush" Color="#FFD166" />
-                    <SolidColorBrush x:Key="TsCheckPassForegroundBrush" Color="#7AD97A" />
-                    <SolidColorBrush x:Key="TsCheckPacketShareBrush" Color="#70A9E8" />
+                    <SolidColorBrush x:Key="TsCheckErrorCellBackgroundBrush" Color="#FF7070" Opacity="0.13" />
+                    <SolidColorBrush x:Key="TsCheckErrorCellForegroundBrush" Color="#FF8585" />
+                    <SolidColorBrush x:Key="TsCheckWarningCellBackgroundBrush" Color="#E6B84A" Opacity="0.13" />
+                    <SolidColorBrush x:Key="TsCheckWarningCellForegroundBrush" Color="#EBC565" />
+                    <SolidColorBrush x:Key="TsCheckPassForegroundBrush" Color="#72C985" />
+                    <SolidColorBrush x:Key="TsCheckPacketShareBrush" Color="#5A94D6" />
                 </ResourceDictionary>
             </ResourceDictionary.ThemeDictionaries>
         </ResourceDictionary>


### PR DESCRIPTION
## Overview

Refines the dark theme palette to improve visual hierarchy, readability, and state consistency while preserving the classic desktop appearance.

## Changes

- Reworks window, control, and workspace surfaces with a restrained blue-gray palette
- Reduces contrast on the brightest classic bevel edges to limit visual noise
- Unifies blue accents across menus, focus states, progress indicators, and interactions
- Improves secondary and disabled text readability on dark surfaces
- Refines DataGrid headers, grid lines, hover, selection, and focus states
- Replaces the overly prominent selected clip background with a subtle blue-gray tint
- Adjusts error, warning, success, and packet-share colors in TS Quick Check
- Improves dark-mode slider track and thumb colors
- Retains the green timeline range indicator as a distinct selected-range state
- Leaves the existing light theme unchanged

## Validation

- Visually verified the main window, clip list, and TS Quick Check window
- Debug build completed successfully
- Release build completed successfully
- XAML resource checks passed

---

## 概述

重新调整深色主题色板，在保留经典桌面界面风格的基础上，改善控件层次、文字可读性和状态色的一致性。

## 主要变更

- 使用低饱和蓝灰色重新组织窗口、控件和工作区层次
- 降低经典凹凸边框最亮边缘的反差，减少大面积界面的视觉噪声
- 统一菜单高亮、焦点、进度条和交互状态的蓝色强调
- 提高次要文字和禁用状态在深色背景下的可读性
- 优化 DataGrid 表头、网格线、悬停、选中和焦点状态
- 将片段卡片的选中背景改为较轻的蓝灰色，避免整块高亮过于突兀
- 调整 TS 快速检查中的错误、警告、成功状态和包占比颜色
- 优化深色模式下滑块轨道与拇指的颜色
- 保留绿色时间范围条，使其继续表达已选区间
- 保持浅色主题原有表现不变

## 验证

- 在主窗口、片段列表和 TS 快速检查窗口中进行了视觉验证
- Debug 构建通过
- Release 构建通过
- XAML 资源检查通过