### PR TITLE
Add bitrate and anomaly timeline to TS Quick Check

### DIFF
--- a/src/TSCutter.GUI/Controls/TsCheckTimeline.cs
+++ b/src/TSCutter.GUI/Controls/TsCheckTimeline.cs
@@ -1,0 +1,546 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Data;
+using Avalonia.Input;
+using Avalonia.Media;
+using TSCutter.GUI.Models;
+
+namespace TSCutter.GUI.Controls;
+
+public sealed class TsCheckTimelineEventSelectedEventArgs(TsCheckEvent item) : EventArgs
+{
+    public TsCheckEvent Item { get; } = item;
+}
+
+/// <summary>
+/// 自绘 TS 码率曲线和异常轨道。控件只绘制折线与像素聚合后的异常标记，
+/// 避免为每个采样点创建 Avalonia 可视元素，长时间录制也能保持低内存和流畅悬停。
+/// </summary>
+public sealed class TsCheckTimeline : Control
+{
+    private const double LeftPadding = 66;
+    private const double RightPadding = 14;
+    private const double TopPadding = 14;
+    private const double BottomPadding = 28;
+    private const double AnomalyLaneHeight = 22;
+
+    public static readonly StyledProperty<IReadOnlyList<TsCheckTimelineBucket>?> BucketsProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IReadOnlyList<TsCheckTimelineBucket>?>(nameof(Buckets));
+
+    public static readonly StyledProperty<IReadOnlyList<TsCheckEvent>?> EventsProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IReadOnlyList<TsCheckEvent>?>(nameof(Events));
+
+    public static readonly StyledProperty<int> SelectedPidProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, int>(nameof(SelectedPid), -1);
+
+    public static readonly StyledProperty<string> SeriesNameProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, string>(nameof(SeriesName), string.Empty);
+
+    public static readonly StyledProperty<TsCheckEvent?> SelectedEventProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, TsCheckEvent?>(
+            nameof(SelectedEvent), defaultBindingMode: BindingMode.TwoWay);
+
+    public static readonly StyledProperty<IBrush?> BackgroundBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(BackgroundBrush));
+
+    public static readonly StyledProperty<IBrush?> PrimaryBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(PrimaryBrush));
+
+    public static readonly StyledProperty<IBrush?> SecondaryBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(SecondaryBrush));
+
+    public static readonly StyledProperty<IBrush?> GridBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(GridBrush));
+
+    public static readonly StyledProperty<IBrush?> TextBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(TextBrush));
+
+    public static readonly StyledProperty<IBrush?> ErrorBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(ErrorBrush));
+
+    public static readonly StyledProperty<IBrush?> WarningBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(WarningBrush));
+
+    public static readonly StyledProperty<IBrush?> TooltipBackgroundBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(TooltipBackgroundBrush));
+
+    public static readonly StyledProperty<IBrush?> TooltipTextBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(TooltipTextBrush));
+
+    public static readonly StyledProperty<IBrush?> TooltipBorderBrushProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, IBrush?>(nameof(TooltipBorderBrush));
+
+    public static readonly StyledProperty<string> TotalTextProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, string>(nameof(TotalText), string.Empty);
+
+    public static readonly StyledProperty<string> NoDataTextProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, string>(nameof(NoDataText), string.Empty);
+
+    public static readonly StyledProperty<string> ErrorTextProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, string>(nameof(ErrorText), string.Empty);
+
+    public static readonly StyledProperty<string> WarningTextProperty =
+        AvaloniaProperty.Register<TsCheckTimeline, string>(nameof(WarningText), string.Empty);
+
+    private Point? _pointerPosition;
+    private Rect _plotBounds;
+    private Rect _anomalyBounds;
+    private double _maxTime;
+    private TsCheckEvent?[] _markerEvents = [];
+    private TsCheckSeverity[] _markerSeverities = [];
+
+    static TsCheckTimeline()
+    {
+        AffectsRender<TsCheckTimeline>(
+            BucketsProperty, EventsProperty, SelectedPidProperty, SeriesNameProperty, SelectedEventProperty,
+            BackgroundBrushProperty, PrimaryBrushProperty, SecondaryBrushProperty, GridBrushProperty,
+            TextBrushProperty, ErrorBrushProperty, WarningBrushProperty,
+            TooltipBackgroundBrushProperty, TooltipTextBrushProperty, TooltipBorderBrushProperty,
+            TotalTextProperty, NoDataTextProperty, ErrorTextProperty, WarningTextProperty);
+    }
+
+    public TsCheckTimeline()
+    {
+        ClipToBounds = true;
+        PointerMoved += OnPointerMoved;
+        PointerExited += OnPointerExited;
+        PointerPressed += OnPointerPressed;
+    }
+
+    public event EventHandler<TsCheckTimelineEventSelectedEventArgs>? EventSelected;
+
+    public IReadOnlyList<TsCheckTimelineBucket>? Buckets
+    {
+        get => GetValue(BucketsProperty);
+        set => SetValue(BucketsProperty, value);
+    }
+
+    public IReadOnlyList<TsCheckEvent>? Events
+    {
+        get => GetValue(EventsProperty);
+        set => SetValue(EventsProperty, value);
+    }
+
+    public int SelectedPid
+    {
+        get => GetValue(SelectedPidProperty);
+        set => SetValue(SelectedPidProperty, value);
+    }
+
+    public string SeriesName
+    {
+        get => GetValue(SeriesNameProperty);
+        set => SetValue(SeriesNameProperty, value);
+    }
+
+    public TsCheckEvent? SelectedEvent
+    {
+        get => GetValue(SelectedEventProperty);
+        set => SetValue(SelectedEventProperty, value);
+    }
+
+    public IBrush? BackgroundBrush
+    {
+        get => GetValue(BackgroundBrushProperty);
+        set => SetValue(BackgroundBrushProperty, value);
+    }
+
+    public IBrush? PrimaryBrush
+    {
+        get => GetValue(PrimaryBrushProperty);
+        set => SetValue(PrimaryBrushProperty, value);
+    }
+
+    public IBrush? SecondaryBrush
+    {
+        get => GetValue(SecondaryBrushProperty);
+        set => SetValue(SecondaryBrushProperty, value);
+    }
+
+    public IBrush? GridBrush
+    {
+        get => GetValue(GridBrushProperty);
+        set => SetValue(GridBrushProperty, value);
+    }
+
+    public IBrush? TextBrush
+    {
+        get => GetValue(TextBrushProperty);
+        set => SetValue(TextBrushProperty, value);
+    }
+
+    public IBrush? ErrorBrush
+    {
+        get => GetValue(ErrorBrushProperty);
+        set => SetValue(ErrorBrushProperty, value);
+    }
+
+    public IBrush? WarningBrush
+    {
+        get => GetValue(WarningBrushProperty);
+        set => SetValue(WarningBrushProperty, value);
+    }
+
+    public IBrush? TooltipBackgroundBrush
+    {
+        get => GetValue(TooltipBackgroundBrushProperty);
+        set => SetValue(TooltipBackgroundBrushProperty, value);
+    }
+
+    public IBrush? TooltipTextBrush
+    {
+        get => GetValue(TooltipTextBrushProperty);
+        set => SetValue(TooltipTextBrushProperty, value);
+    }
+
+    public IBrush? TooltipBorderBrush
+    {
+        get => GetValue(TooltipBorderBrushProperty);
+        set => SetValue(TooltipBorderBrushProperty, value);
+    }
+
+    public string TotalText
+    {
+        get => GetValue(TotalTextProperty);
+        set => SetValue(TotalTextProperty, value);
+    }
+
+    public string NoDataText
+    {
+        get => GetValue(NoDataTextProperty);
+        set => SetValue(NoDataTextProperty, value);
+    }
+
+    public string ErrorText
+    {
+        get => GetValue(ErrorTextProperty);
+        set => SetValue(ErrorTextProperty, value);
+    }
+
+    public string WarningText
+    {
+        get => GetValue(WarningTextProperty);
+        set => SetValue(WarningTextProperty, value);
+    }
+
+    public override void Render(DrawingContext context)
+    {
+        base.Render(context);
+        var background = BackgroundBrush ?? Brushes.Transparent;
+        var textBrush = TextBrush ?? Brushes.Gray;
+        var gridBrush = GridBrush ?? textBrush;
+        context.FillRectangle(background, new Rect(Bounds.Size));
+
+        _plotBounds = new Rect(
+            LeftPadding, TopPadding,
+            Math.Max(0, Bounds.Width - LeftPadding - RightPadding),
+            Math.Max(0, Bounds.Height - TopPadding - BottomPadding - AnomalyLaneHeight));
+        _anomalyBounds = new Rect(
+            _plotBounds.X, _plotBounds.Bottom,
+            _plotBounds.Width, AnomalyLaneHeight);
+
+        var buckets = Buckets;
+        if (buckets is null || buckets.Count == 0 || _plotBounds.Width < 20 || _plotBounds.Height < 20)
+        {
+            DrawCenteredText(context, NoDataText, textBrush);
+            return;
+        }
+
+        _maxTime = GetMaxTime(buckets, Events);
+        var maxBitrate = GetMaxBitrate(buckets, SelectedPid);
+        if (_maxTime <= 0 || maxBitrate <= 0)
+        {
+            DrawCenteredText(context, NoDataText, textBrush);
+            return;
+        }
+        maxBitrate = NiceCeiling(maxBitrate);
+
+        DrawGrid(context, gridBrush, textBrush, maxBitrate);
+        if (SelectedPid >= 0)
+            DrawSeries(context, buckets, -1, maxBitrate, SecondaryBrush ?? gridBrush, 1, 0.55);
+        DrawSeries(context, buckets, SelectedPid, maxBitrate, PrimaryBrush ?? Brushes.DodgerBlue, 2, 1);
+        DrawAnomalies(context, Events, gridBrush);
+        DrawPointerOverlay(context, buckets, maxBitrate, textBrush, background, gridBrush);
+    }
+
+    private void DrawGrid(DrawingContext context, IBrush gridBrush, IBrush textBrush, double maxBitrate)
+    {
+        var gridPen = new Pen(gridBrush, 0.6);
+        for (var row = 0; row <= 4; row++)
+        {
+            var ratio = row / 4.0;
+            var y = _plotBounds.Bottom - _plotBounds.Height * ratio;
+            using (context.PushOpacity(0.28))
+                context.DrawLine(gridPen, new Point(_plotBounds.Left, y), new Point(_plotBounds.Right, y));
+            var label = CreateText(FormatBitrate(maxBitrate * ratio), 11, textBrush);
+            context.DrawText(label, new Point(Math.Max(2, _plotBounds.Left - label.Width - 7), y - label.Height / 2));
+        }
+
+        for (var column = 0; column <= 4; column++)
+        {
+            var ratio = column / 4.0;
+            var x = _plotBounds.Left + _plotBounds.Width * ratio;
+            using (context.PushOpacity(0.28))
+                context.DrawLine(gridPen, new Point(x, _plotBounds.Top), new Point(x, _anomalyBounds.Bottom));
+            var label = CreateText(FormatTime(_maxTime * ratio), 11, textBrush);
+            var labelX = Math.Clamp(x - label.Width / 2, _plotBounds.Left, _plotBounds.Right - label.Width);
+            context.DrawText(label, new Point(labelX, _anomalyBounds.Bottom + 4));
+        }
+        using (context.PushOpacity(0.55))
+            context.DrawLine(new Pen(gridBrush, 1),
+                new Point(_anomalyBounds.Left, _anomalyBounds.Top),
+                new Point(_anomalyBounds.Right, _anomalyBounds.Top));
+    }
+
+    private void DrawSeries(
+        DrawingContext context, IReadOnlyList<TsCheckTimelineBucket> buckets,
+        int pid, double maxBitrate, IBrush brush, double thickness, double opacity)
+    {
+        var pen = new Pen(brush, thickness, lineCap: PenLineCap.Round, lineJoin: PenLineJoin.Round);
+        using var opacityScope = context.PushOpacity(opacity);
+        Point? previous = null;
+        var previousSegment = -1;
+        foreach (var bucket in buckets)
+        {
+            var bitrate = pid < 0 ? bucket.TotalBitrate : bucket.GetPidBitrate(pid);
+            var x = TimeToX(bucket.StartSeconds + bucket.DurationSeconds / 2);
+            var y = _plotBounds.Bottom - Math.Clamp(bitrate / maxBitrate, 0, 1) * _plotBounds.Height;
+            var current = new Point(x, y);
+            if (previous is { } point && previousSegment == bucket.Segment)
+                context.DrawLine(pen, point, current);
+            previous = current;
+            previousSegment = bucket.Segment;
+        }
+    }
+
+    private void DrawAnomalies(DrawingContext context, IReadOnlyList<TsCheckEvent>? events, IBrush fallbackBrush)
+    {
+        var pixelWidth = Math.Max(1, (int)Math.Ceiling(_plotBounds.Width));
+        EnsureMarkerBuffers(pixelWidth);
+        Array.Clear(_markerEvents);
+        Array.Clear(_markerSeverities);
+
+        if (events is not null)
+        {
+            foreach (var item in events)
+            {
+                if (item.TimeSeconds is not { } time || time < 0 || time > _maxTime)
+                    continue;
+                var pixel = Math.Clamp((int)(time / _maxTime * (pixelWidth - 1)), 0, pixelWidth - 1);
+                if (_markerEvents[pixel] is null || item.Severity > _markerSeverities[pixel])
+                {
+                    _markerEvents[pixel] = item;
+                    _markerSeverities[pixel] = item.Severity;
+                }
+            }
+        }
+
+        for (var pixel = 0; pixel < pixelWidth; pixel++)
+        {
+            var item = _markerEvents[pixel];
+            if (item is null)
+                continue;
+            var brush = item.Severity == TsCheckSeverity.Error
+                ? ErrorBrush ?? fallbackBrush
+                : WarningBrush ?? fallbackBrush;
+            var x = _anomalyBounds.Left + pixel;
+            var width = ReferenceEquals(item, SelectedEvent) ? 4 : 2;
+            context.FillRectangle(brush, new Rect(x - width / 2.0, _anomalyBounds.Top + 4, width, 14));
+        }
+    }
+
+    private void DrawPointerOverlay(
+        DrawingContext context, IReadOnlyList<TsCheckTimelineBucket> buckets, double maxBitrate,
+        IBrush textBrush, IBrush background, IBrush borderBrush)
+    {
+        if (_pointerPosition is not { } pointer || !_plotBounds.Contains(pointer))
+            return;
+
+        var time = Math.Clamp((pointer.X - _plotBounds.Left) / _plotBounds.Width, 0, 1) * _maxTime;
+        var bucket = FindBucket(buckets, time);
+        if (bucket is null)
+            return;
+
+        context.DrawLine(new Pen(borderBrush, 1),
+            new Point(pointer.X, _plotBounds.Top), new Point(pointer.X, _anomalyBounds.Bottom));
+
+        var totalBitrate = bucket.TotalBitrate;
+        var content = $"{FormatTime(time)}\n{TotalText}  {FormatBitrate(totalBitrate)}";
+        if (SelectedPid >= 0)
+            content += $"\n{SeriesName}  {FormatBitrate(bucket.GetPidBitrate(SelectedPid))}";
+
+        var markerPixel = Math.Clamp((int)(time / _maxTime * (_markerEvents.Length - 1)), 0, _markerEvents.Length - 1);
+        if (_markerEvents[markerPixel] is { } marker)
+            content += $"\n{(marker.Severity == TsCheckSeverity.Error ? ErrorText : WarningText)}";
+
+        var tooltipTextBrush = TooltipTextBrush ?? textBrush;
+        var tooltipBackground = TooltipBackgroundBrush ?? background;
+        var tooltipBorder = TooltipBorderBrush ?? borderBrush;
+        var text = CreateText(content, 12, tooltipTextBrush);
+        const double horizontalPadding = 12;
+        const double verticalPadding = 7;
+        // Classic 字体可能存在左右 overhang，仅使用 Width 会让末尾字形压到边框上。
+        var textWidth = Math.Max(text.Width, text.WidthIncludingTrailingWhitespace) +
+                        Math.Abs(text.OverhangLeading) + Math.Abs(text.OverhangTrailing);
+        var tooltipSize = new Size(
+            textWidth + horizontalPadding * 2,
+            text.Height + verticalPadding * 2);
+        var tooltipX = pointer.X + 10;
+        if (tooltipX + tooltipSize.Width > _plotBounds.Right - 4)
+            tooltipX = pointer.X - tooltipSize.Width - 10;
+        tooltipX = Math.Clamp(
+            tooltipX,
+            _plotBounds.Left + 4,
+            Math.Max(_plotBounds.Left + 4, _plotBounds.Right - tooltipSize.Width - 4));
+        var tooltipY = pointer.Y - tooltipSize.Height - 8;
+        if (tooltipY < _plotBounds.Top + 4)
+            tooltipY = pointer.Y + 8;
+        tooltipY = Math.Clamp(
+            tooltipY,
+            _plotBounds.Top + 4,
+            Math.Max(_plotBounds.Top + 4, _plotBounds.Bottom - tooltipSize.Height - 4));
+        var tooltipRect = new Rect(new Point(tooltipX, tooltipY), tooltipSize);
+        context.FillRectangle(tooltipBackground, tooltipRect);
+        context.DrawRectangle(new Pen(tooltipBorder, 1.5), tooltipRect);
+        context.DrawText(text, tooltipRect.Position + new Vector(
+            horizontalPadding + Math.Abs(text.OverhangLeading), verticalPadding));
+    }
+
+    private void OnPointerMoved(object? sender, PointerEventArgs eventArgs)
+    {
+        _pointerPosition = eventArgs.GetPosition(this);
+        InvalidateVisual();
+    }
+
+    private void OnPointerExited(object? sender, PointerEventArgs eventArgs)
+    {
+        _pointerPosition = null;
+        InvalidateVisual();
+    }
+
+    private void OnPointerPressed(object? sender, PointerPressedEventArgs eventArgs)
+    {
+        if (_markerEvents.Length == 0 || _maxTime <= 0)
+            return;
+        var point = eventArgs.GetPosition(this);
+        if (!_anomalyBounds.Contains(point))
+            return;
+        var pixel = Math.Clamp((int)(point.X - _anomalyBounds.Left), 0, _markerEvents.Length - 1);
+        for (var distance = 0; distance <= 4; distance++)
+        {
+            var left = pixel - distance;
+            if (left >= 0 && _markerEvents[left] is { } leftEvent)
+            {
+                SelectEvent(leftEvent);
+                eventArgs.Handled = true;
+                return;
+            }
+            var right = pixel + distance;
+            if (right < _markerEvents.Length && _markerEvents[right] is { } rightEvent)
+            {
+                SelectEvent(rightEvent);
+                eventArgs.Handled = true;
+                return;
+            }
+        }
+    }
+
+    private void SelectEvent(TsCheckEvent item)
+    {
+        SetCurrentValue(SelectedEventProperty, item);
+        EventSelected?.Invoke(this, new TsCheckTimelineEventSelectedEventArgs(item));
+    }
+
+    private void EnsureMarkerBuffers(int length)
+    {
+        if (_markerEvents.Length == length)
+            return;
+        _markerEvents = new TsCheckEvent?[length];
+        _markerSeverities = new TsCheckSeverity[length];
+    }
+
+    private static TsCheckTimelineBucket? FindBucket(
+        IReadOnlyList<TsCheckTimelineBucket> buckets, double time)
+    {
+        var low = 0;
+        var high = buckets.Count - 1;
+        while (low <= high)
+        {
+            var middle = low + (high - low) / 2;
+            var bucket = buckets[middle];
+            if (time < bucket.StartSeconds)
+                high = middle - 1;
+            else if (time > bucket.EndSeconds)
+                low = middle + 1;
+            else
+                return bucket;
+        }
+        return null;
+    }
+
+    private double TimeToX(double seconds) =>
+        _plotBounds.Left + Math.Clamp(seconds / _maxTime, 0, 1) * _plotBounds.Width;
+
+    private static double GetMaxTime(
+        IReadOnlyList<TsCheckTimelineBucket> buckets, IReadOnlyList<TsCheckEvent>? events)
+    {
+        var result = buckets[^1].EndSeconds;
+        if (events is null)
+            return result;
+        foreach (var item in events)
+        {
+            if (item.TimeSeconds is { } time)
+                result = Math.Max(result, time);
+        }
+        return result;
+    }
+
+    private static double GetMaxBitrate(IReadOnlyList<TsCheckTimelineBucket> buckets, int pid)
+    {
+        var result = 0.0;
+        foreach (var bucket in buckets)
+        {
+            result = Math.Max(result, bucket.TotalBitrate);
+            if (pid >= 0)
+                result = Math.Max(result, bucket.GetPidBitrate(pid));
+        }
+        return result;
+    }
+
+    private static double NiceCeiling(double value)
+    {
+        if (value <= 0)
+            return 1;
+        var exponent = Math.Pow(10, Math.Floor(Math.Log10(value)));
+        var normalized = value / exponent;
+        var ceiling = normalized <= 1 ? 1 : normalized <= 2 ? 2 : normalized <= 5 ? 5 : 10;
+        return ceiling * exponent;
+    }
+
+    private static string FormatBitrate(double bitsPerSecond) => bitsPerSecond >= 1_000_000
+        ? $"{bitsPerSecond / 1_000_000:0.##} Mb/s"
+        : $"{bitsPerSecond / 1_000:0.##} kb/s";
+
+    private static string FormatTime(double seconds)
+    {
+        var time = TimeSpan.FromSeconds(Math.Max(0, seconds));
+        return time.TotalHours >= 1
+            ? $"{(int)time.TotalHours:00}:{time.Minutes:00}:{time.Seconds:00}"
+            : $"{time.Minutes:00}:{time.Seconds:00}";
+    }
+
+    private static FormattedText CreateText(string text, double size, IBrush brush) => new(
+        text, CultureInfo.CurrentCulture, FlowDirection.LeftToRight,
+        Typeface.Default, size, brush);
+
+    private void DrawCenteredText(DrawingContext context, string text, IBrush brush)
+    {
+        var formatted = CreateText(text, 13, brush);
+        context.DrawText(formatted, new Point(
+            Math.Max(0, (Bounds.Width - formatted.Width) / 2),
+            Math.Max(0, (Bounds.Height - formatted.Height) / 2)));
+    }
+}

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -205,6 +205,11 @@
     <x:String x:Key="String.TsCheck.Column.Warnings">Warnings</x:String>
     <x:String x:Key="String.TsCheck.View.Summary">Summary</x:String>
     <x:String x:Key="String.TsCheck.View.Details">Details</x:String>
+    <x:String x:Key="String.TsCheck.View.Timeline">Timeline</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.Stream">Series:</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.TotalTs">Total TS</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.NoData">Waiting for a valid PCR timeline...</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.Hint">Hover to inspect bitrate; click a red or yellow marker to open its detail.</x:String>
     <x:String x:Key="String.TsCheck.Column.Type">Type</x:String>
     <x:String x:Key="String.TsCheck.Column.Packet">Packet</x:String>
     <x:String x:Key="String.TsCheck.Column.Description">Description</x:String>
@@ -285,6 +290,13 @@
     <x:String x:Key="String.TsCheck.Report.Warnings">Warnings</x:String>
     <x:String x:Key="String.TsCheck.Report.Elapsed">Elapsed</x:String>
     <x:String x:Key="String.TsCheck.Report.AverageSpeed">Average speed</x:String>
+    <x:String x:Key="String.TsCheck.Report.BitrateTimeline">Bitrate timeline</x:String>
+    <x:String x:Key="String.TsCheck.Report.ReferencePcr">Reference PCR PID</x:String>
+    <x:String x:Key="String.TsCheck.Report.TimelineDuration">Timeline duration</x:String>
+    <x:String x:Key="String.TsCheck.Report.TimelineSamples">Timeline samples</x:String>
+    <x:String x:Key="String.TsCheck.Report.AverageBitrate">Average TS bitrate</x:String>
+    <x:String x:Key="String.TsCheck.Report.PeakBitrate">Peak TS bitrate</x:String>
+    <x:String x:Key="String.TsCheck.Report.BitrateValue">{0:0.###} Mb/s</x:String>
     <x:String x:Key="String.TsCheck.Report.Programs">Programs and streams</x:String>
     <x:String x:Key="String.TsCheck.Report.NoPrograms">No valid PAT/PMT program was found.</x:String>
     <x:String x:Key="String.TsCheck.Report.ProgramLine">Program {0}: PMT {1}, PCR {2}</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -205,6 +205,11 @@
     <x:String x:Key="String.TsCheck.Column.Warnings">警告数</x:String>
     <x:String x:Key="String.TsCheck.View.Summary">摘要</x:String>
     <x:String x:Key="String.TsCheck.View.Details">详情</x:String>
+    <x:String x:Key="String.TsCheck.View.Timeline">时间轴</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.Stream">曲线：</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.TotalTs">TS 总码率</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.NoData">正在等待有效的 PCR 时间轴...</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.Hint">悬停查看码率；点击红色或黄色标记可打开对应详情。</x:String>
     <x:String x:Key="String.TsCheck.Column.Type">类型</x:String>
     <x:String x:Key="String.TsCheck.Column.Packet">Packet</x:String>
     <x:String x:Key="String.TsCheck.Column.Description">说明</x:String>
@@ -285,6 +290,13 @@
     <x:String x:Key="String.TsCheck.Report.Warnings">警告</x:String>
     <x:String x:Key="String.TsCheck.Report.Elapsed">扫描耗时</x:String>
     <x:String x:Key="String.TsCheck.Report.AverageSpeed">平均速度</x:String>
+    <x:String x:Key="String.TsCheck.Report.BitrateTimeline">码率时间轴</x:String>
+    <x:String x:Key="String.TsCheck.Report.ReferencePcr">参考 PCR PID</x:String>
+    <x:String x:Key="String.TsCheck.Report.TimelineDuration">时间轴时长</x:String>
+    <x:String x:Key="String.TsCheck.Report.TimelineSamples">时间轴采样数</x:String>
+    <x:String x:Key="String.TsCheck.Report.AverageBitrate">TS 平均码率</x:String>
+    <x:String x:Key="String.TsCheck.Report.PeakBitrate">TS 峰值码率</x:String>
+    <x:String x:Key="String.TsCheck.Report.BitrateValue">{0:0.###} Mb/s</x:String>
     <x:String x:Key="String.TsCheck.Report.Programs">节目与轨道</x:String>
     <x:String x:Key="String.TsCheck.Report.NoPrograms">未找到有效的 PAT/PMT 节目。</x:String>
     <x:String x:Key="String.TsCheck.Report.ProgramLine">节目 {0}：PMT {1}，PCR {2}</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -205,6 +205,11 @@
     <x:String x:Key="String.TsCheck.Column.Warnings">警告數</x:String>
     <x:String x:Key="String.TsCheck.View.Summary">摘要</x:String>
     <x:String x:Key="String.TsCheck.View.Details">詳細資料</x:String>
+    <x:String x:Key="String.TsCheck.View.Timeline">時間軸</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.Stream">曲線：</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.TotalTs">TS 總位元率</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.NoData">正在等待有效的 PCR 時間軸...</x:String>
+    <x:String x:Key="String.TsCheck.Timeline.Hint">懸停查看位元率；點擊紅色或黃色標記可開啟對應詳細資料。</x:String>
     <x:String x:Key="String.TsCheck.Column.Type">類型</x:String>
     <x:String x:Key="String.TsCheck.Column.Packet">Packet</x:String>
     <x:String x:Key="String.TsCheck.Column.Description">說明</x:String>
@@ -285,6 +290,13 @@
     <x:String x:Key="String.TsCheck.Report.Warnings">警告</x:String>
     <x:String x:Key="String.TsCheck.Report.Elapsed">掃描耗時</x:String>
     <x:String x:Key="String.TsCheck.Report.AverageSpeed">平均速度</x:String>
+    <x:String x:Key="String.TsCheck.Report.BitrateTimeline">位元率時間軸</x:String>
+    <x:String x:Key="String.TsCheck.Report.ReferencePcr">參考 PCR PID</x:String>
+    <x:String x:Key="String.TsCheck.Report.TimelineDuration">時間軸時長</x:String>
+    <x:String x:Key="String.TsCheck.Report.TimelineSamples">時間軸取樣數</x:String>
+    <x:String x:Key="String.TsCheck.Report.AverageBitrate">TS 平均位元率</x:String>
+    <x:String x:Key="String.TsCheck.Report.PeakBitrate">TS 峰值位元率</x:String>
+    <x:String x:Key="String.TsCheck.Report.BitrateValue">{0:0.###} Mb/s</x:String>
     <x:String x:Key="String.TsCheck.Report.Programs">節目與軌道</x:String>
     <x:String x:Key="String.TsCheck.Report.NoPrograms">未找到有效的 PAT/PMT 節目。</x:String>
     <x:String x:Key="String.TsCheck.Report.ProgramLine">節目 {0}：PMT {1}，PCR {2}</x:String>

--- a/src/TSCutter.GUI/Models/TsCheckEventView.cs
+++ b/src/TSCutter.GUI/Models/TsCheckEventView.cs
@@ -6,6 +6,7 @@ public sealed class TsCheckEventView
 {
     public TsCheckEventView(TsCheckEvent item, TsCheckTextFormatter text, TsCheckResult? result = null)
     {
+        Item = item;
         Severity = text.FormatSeverity(item.Severity);
         SourceTime = text.FormatEventSourceTime(item);
         ZeroBasedTime = text.FormatEventZeroBasedTime(item);
@@ -18,6 +19,7 @@ public sealed class TsCheckEventView
         Message = text.FormatEventMessage(item);
     }
 
+    public TsCheckEvent Item { get; }
     public string Severity { get; }
     public string SourceTime { get; }
     public string ZeroBasedTime { get; }

--- a/src/TSCutter.GUI/Models/TsCheckModels.cs
+++ b/src/TSCutter.GUI/Models/TsCheckModels.cs
@@ -171,8 +171,10 @@ public sealed class TsCheckResult
     public int GlobalErrorCount { get; set; }
     public int GlobalWarningCount { get; set; }
     public List<TsCheckEvent> Events { get; } = [];
+    public List<TsCheckTimelineBucket> Timeline { get; } = [];
     public Dictionary<int, TsCheckPidSummary> Pids { get; } = [];
     public Dictionary<int, TsCheckProgramSummary> Programs { get; } = [];
+    public int TimelineReferencePcrPid { get; set; } = -1;
     public int ErrorCount => TotalErrorCount;
     public int WarningCount => TotalWarningCount;
     public TsCheckVerdict Verdict => WasCancelled
@@ -182,6 +184,44 @@ public sealed class TsCheckResult
             : WarningCount > 0
                 ? TsCheckVerdict.Warning
                 : TsCheckVerdict.Pass;
+}
+
+public readonly record struct TsCheckTimelinePidSample(int Pid, double PacketCount);
+
+public sealed class TsCheckTimelineBucket
+{
+    private const int TransportPacketBits = 188 * 8;
+
+    public required double StartSeconds { get; init; }
+    public required double DurationSeconds { get; init; }
+    public required double TotalPacketCount { get; init; }
+    public required int Segment { get; init; }
+    public TsCheckTimelinePidSample[] Pids { get; init; } = [];
+    public double EndSeconds => StartSeconds + DurationSeconds;
+    public double TotalBitrate => DurationSeconds > 0
+        ? TotalPacketCount * TransportPacketBits / DurationSeconds
+        : 0;
+
+    public double GetPidBitrate(int pid)
+    {
+        if (DurationSeconds <= 0)
+            return 0;
+        // 每个桶的 PID 采样已排序，绘图时使用二分查找，避免长时间轴反复线性扫描全部 PID。
+        var low = 0;
+        var high = Pids.Length - 1;
+        while (low <= high)
+        {
+            var middle = low + (high - low) / 2;
+            var sample = Pids[middle];
+            if (sample.Pid == pid)
+                return sample.PacketCount * TransportPacketBits / DurationSeconds;
+            if (sample.Pid < pid)
+                low = middle + 1;
+            else
+                high = middle - 1;
+        }
+        return 0;
+    }
 }
 
 public sealed class TsStreamAnalyzeOptions
@@ -214,7 +254,8 @@ public readonly record struct TsCheckProgress(
     double BytesPerSecond,
     TimeSpan Elapsed,
     TsCheckPidProgress[] Pids,
-    TsCheckEvent? NewEvent)
+    TsCheckEvent? NewEvent,
+    TsCheckTimelineBucket[] Timeline)
 {
     public double Percent => FileSize > 0 ? BytesScanned * 100.0 / FileSize : 0;
 }

--- a/src/TSCutter.GUI/Models/TsCheckTimelineStreamView.cs
+++ b/src/TSCutter.GUI/Models/TsCheckTimelineStreamView.cs
@@ -1,0 +1,7 @@
+namespace TSCutter.GUI.Models;
+
+public sealed class TsCheckTimelineStreamView(int pid, string displayText)
+{
+    public int Pid { get; } = pid;
+    public string DisplayText { get; } = displayText;
+}

--- a/src/TSCutter.GUI/Services/TsStreamAnalyzer.cs
+++ b/src/TSCutter.GUI/Services/TsStreamAnalyzer.cs
@@ -20,6 +20,8 @@ public sealed class TsStreamAnalyzer
     private const double PcrGapThresholdSeconds = 0.5;
     private const double TimestampJumpThresholdSeconds = 10;
     private const double AvDriftThresholdSeconds = 0.5;
+    private const int MaxTimelineBuckets = 4_096;
+    private const double InitialTimelineBucketSeconds = 1;
 
     private readonly Dictionary<int, PidState> _pidStates = [];
     private readonly Dictionary<int, PsiAssembler> _psiAssemblers = [];
@@ -46,6 +48,15 @@ public sealed class TsStreamAnalyzer
     private TsStreamAnalyzeOptions _options = new();
     private long _lastCatalogChangePacket;
     private bool _stopRequested;
+    private int _timelineReferencePcrPid = -1;
+    private bool _timelineStarted;
+    private double _timelineLastClockSeconds;
+    private double _timelineBucketStartSeconds;
+    private double _timelineBucketDurationSeconds = InitialTimelineBucketSeconds;
+    private double _timelineBucketPacketCount;
+    private long _timelineIntervalPacketCount;
+    private int _timelineSegment;
+    private int _timelineCompactionThreshold = MaxTimelineBuckets;
 
     public async Task<TsCheckResult> AnalyzeAsync(
         string filePath,
@@ -156,6 +167,15 @@ public sealed class TsStreamAnalyzer
         _options = options ?? new TsStreamAnalyzeOptions();
         _lastCatalogChangePacket = 0;
         _stopRequested = false;
+        _timelineReferencePcrPid = -1;
+        _timelineStarted = false;
+        _timelineLastClockSeconds = 0;
+        _timelineBucketStartSeconds = 0;
+        _timelineBucketDurationSeconds = InitialTimelineBucketSeconds;
+        _timelineBucketPacketCount = 0;
+        _timelineIntervalPacketCount = 0;
+        _timelineSegment = 0;
+        _timelineCompactionThreshold = MaxTimelineBuckets;
         _psiAssemblers[0] = new PsiAssembler();
     }
 
@@ -247,6 +267,11 @@ public sealed class TsStreamAnalyzer
 
         var state = GetPidState(pid);
         state.Summary.PacketCount++;
+        if (_timelineStarted)
+        {
+            state.TimelineIntervalPacketCount++;
+            _timelineIntervalPacketCount++;
+        }
         if (hasPayload)
             state.Summary.PayloadPacketCount++;
 
@@ -400,6 +425,7 @@ public sealed class TsStreamAnalyzer
         _lastKnownPcr90k = pcr;
         _lastKnownClock90k = pcr;
         SetTimelineOrigin(pcr);
+        UpdateTimeline(pid, ptsToSeconds(pcr), discontinuity);
         if (_pcrPidPrograms.TryGetValue(pid, out var programNumber))
             CheckAvSyncAtPcr(programNumber, pcr, fileOffset);
     }
@@ -1033,11 +1059,12 @@ public sealed class TsStreamAnalyzer
         _progress.Report(new TsCheckProgress(
             bytesScanned, _result.FileSize, _packetIndex, _errorCount, _warningCount,
             bytesScanned / Math.Max(0.001, _stopwatch.Elapsed.TotalSeconds), _stopwatch.Elapsed,
-            pidSnapshot, progressEvent));
+            pidSnapshot, progressEvent, _result.Timeline.ToArray()));
     }
 
     private void CompleteResult(long bytesScanned, bool cancelled)
     {
+        CompleteTimeline();
         _result.PacketCount = _packetIndex;
         _result.BytesScanned = Math.Min(_result.FileSize, bytesScanned);
         _result.Elapsed = _stopwatch.Elapsed;
@@ -1046,6 +1073,202 @@ public sealed class TsStreamAnalyzer
         _result.TotalWarningCount = _warningCount;
         _result.GlobalErrorCount = _globalErrorCount;
         _result.GlobalWarningCount = _globalWarningCount;
+    }
+
+    private void UpdateTimeline(int pid, double clockSeconds, bool discontinuity)
+    {
+        // 码率以首个已确认的节目 PCR 为参考时钟，避免多个节目交错 PCR 导致时间轴来回跳动。
+        if (_timelineReferencePcrPid < 0)
+        {
+            if (!_pcrPidPrograms.ContainsKey(pid))
+                return;
+            _timelineReferencePcrPid = pid;
+            _result.TimelineReferencePcrPid = pid;
+            StartTimeline(clockSeconds);
+            return;
+        }
+        if (pid != _timelineReferencePcrPid || !_timelineStarted)
+            return;
+
+        var intervalDuration = clockSeconds - _timelineLastClockSeconds;
+        if (discontinuity || intervalDuration <= 0 || intervalDuration > TimestampJumpThresholdSeconds)
+        {
+            // 时钟不连续时保留已有片段并开启新段，不能把跳变区间平均成虚假的低码率。
+            FlushTimelineBucket(_timelineLastClockSeconds - _timelineBucketStartSeconds);
+            _timelineSegment++;
+            ResetTimelineCounters();
+            _timelineBucketStartSeconds = Math.Max(clockSeconds, GetTimelineEndSeconds());
+            _timelineLastClockSeconds = _timelineBucketStartSeconds;
+            return;
+        }
+
+        var cursor = _timelineLastClockSeconds;
+        while (cursor < clockSeconds)
+        {
+            var bucketEnd = _timelineBucketStartSeconds + _timelineBucketDurationSeconds;
+            var overlap = Math.Min(clockSeconds, bucketEnd) - cursor;
+            if (overlap <= 0)
+                break;
+
+            var ratio = overlap / intervalDuration;
+            _timelineBucketPacketCount += _timelineIntervalPacketCount * ratio;
+            foreach (var state in _pidStates.Values)
+                state.TimelineBucketPacketCount += state.TimelineIntervalPacketCount * ratio;
+
+            cursor += overlap;
+            if (cursor >= bucketEnd - 0.000_001)
+                SealTimelineBucket(_timelineBucketDurationSeconds);
+        }
+
+        ResetTimelineIntervalCounters();
+        _timelineLastClockSeconds = clockSeconds;
+    }
+
+    private void StartTimeline(double clockSeconds)
+    {
+        _timelineStarted = true;
+        _timelineLastClockSeconds = clockSeconds;
+        _timelineBucketStartSeconds = clockSeconds;
+        ResetTimelineCounters();
+    }
+
+    private void CompleteTimeline()
+    {
+        if (!_timelineStarted)
+            return;
+        FlushTimelineBucket(_timelineLastClockSeconds - _timelineBucketStartSeconds);
+        ResetTimelineIntervalCounters();
+        _timelineStarted = false;
+    }
+
+    private void FlushTimelineBucket(double durationSeconds)
+    {
+        if (durationSeconds <= 0 || _timelineBucketPacketCount <= 0)
+            return;
+        SealTimelineBucket(durationSeconds);
+    }
+
+    private void SealTimelineBucket(double durationSeconds)
+    {
+        var sampleCount = 0;
+        foreach (var state in _pidStates.Values)
+        {
+            if (state.TimelineBucketPacketCount > 0)
+                sampleCount++;
+        }
+
+        var samples = new TsCheckTimelinePidSample[sampleCount];
+        var index = 0;
+        foreach (var state in _pidStates.Values)
+        {
+            if (state.TimelineBucketPacketCount > 0)
+            {
+                samples[index++] = new TsCheckTimelinePidSample(
+                    state.Summary.Pid, state.TimelineBucketPacketCount);
+            }
+            state.TimelineBucketPacketCount = 0;
+        }
+        Array.Sort(samples, static (left, right) => left.Pid.CompareTo(right.Pid));
+
+        _result.Timeline.Add(new TsCheckTimelineBucket
+        {
+            StartSeconds = _timelineBucketStartSeconds,
+            DurationSeconds = durationSeconds,
+            TotalPacketCount = _timelineBucketPacketCount,
+            Segment = _timelineSegment,
+            Pids = samples
+        });
+        _timelineBucketStartSeconds += durationSeconds;
+        _timelineBucketPacketCount = 0;
+
+        if (_result.Timeline.Count >= _timelineCompactionThreshold)
+            CompactTimeline();
+    }
+
+    private void CompactTimeline()
+    {
+        var source = _result.Timeline;
+        var compacted = new List<TsCheckTimelineBucket>((source.Count + 1) / 2);
+        for (var index = 0; index < source.Count;)
+        {
+            var first = source[index++];
+            if (index < source.Count && source[index].Segment == first.Segment)
+            {
+                compacted.Add(MergeTimelineBuckets(first, source[index++]));
+            }
+            else
+            {
+                compacted.Add(first);
+            }
+        }
+
+        source.Clear();
+        source.AddRange(compacted);
+        _timelineBucketDurationSeconds *= 2;
+        // 如果异常分段过多导致本轮无法充分压缩，推迟下一轮，避免每增加一个桶都重复整理。
+        _timelineCompactionThreshold = source.Count < MaxTimelineBuckets
+            ? MaxTimelineBuckets
+            : source.Count + MaxTimelineBuckets;
+    }
+
+    private static TsCheckTimelineBucket MergeTimelineBuckets(
+        TsCheckTimelineBucket first, TsCheckTimelineBucket second)
+    {
+        var merged = new TsCheckTimelinePidSample[first.Pids.Length + second.Pids.Length];
+        var firstIndex = 0;
+        var secondIndex = 0;
+        var outputIndex = 0;
+        while (firstIndex < first.Pids.Length || secondIndex < second.Pids.Length)
+        {
+            if (secondIndex >= second.Pids.Length ||
+                firstIndex < first.Pids.Length && first.Pids[firstIndex].Pid < second.Pids[secondIndex].Pid)
+            {
+                merged[outputIndex++] = first.Pids[firstIndex++];
+            }
+            else if (firstIndex >= first.Pids.Length ||
+                     second.Pids[secondIndex].Pid < first.Pids[firstIndex].Pid)
+            {
+                merged[outputIndex++] = second.Pids[secondIndex++];
+            }
+            else
+            {
+                merged[outputIndex++] = new TsCheckTimelinePidSample(
+                    first.Pids[firstIndex].Pid,
+                    first.Pids[firstIndex].PacketCount + second.Pids[secondIndex].PacketCount);
+                firstIndex++;
+                secondIndex++;
+            }
+        }
+        if (outputIndex != merged.Length)
+            Array.Resize(ref merged, outputIndex);
+
+        return new TsCheckTimelineBucket
+        {
+            StartSeconds = first.StartSeconds,
+            DurationSeconds = first.DurationSeconds + second.DurationSeconds,
+            TotalPacketCount = first.TotalPacketCount + second.TotalPacketCount,
+            Segment = first.Segment,
+            Pids = merged
+        };
+    }
+
+    private double GetTimelineEndSeconds() => _result.Timeline.Count > 0
+        ? _result.Timeline[^1].EndSeconds
+        : 0;
+
+    private void ResetTimelineCounters()
+    {
+        _timelineBucketPacketCount = 0;
+        foreach (var state in _pidStates.Values)
+            state.TimelineBucketPacketCount = 0;
+        ResetTimelineIntervalCounters();
+    }
+
+    private void ResetTimelineIntervalCounters()
+    {
+        _timelineIntervalPacketCount = 0;
+        foreach (var state in _pidStates.Values)
+            state.TimelineIntervalPacketCount = 0;
     }
 
     private void ValidateCompletedScan(long fileSize)
@@ -1178,6 +1401,9 @@ public sealed class TsStreamAnalyzer
         public byte[] MpegAudioProbeTail { get; } = new byte[3];
         public int MpegAudioProbeTailLength;
         public int MpegAudioProbeBytes;
+        // 时间轴仅在 PCR 到达时汇总，逐包热路径只做整数累加，不创建采样对象。
+        public long TimelineIntervalPacketCount;
+        public double TimelineBucketPacketCount;
 
         public void ResetContinuity() => HasContinuity = false;
 

--- a/src/TSCutter.GUI/Utils/TsCheckReportBuilder.cs
+++ b/src/TSCutter.GUI/Utils/TsCheckReportBuilder.cs
@@ -33,6 +33,27 @@ public sealed class TsCheckReportBuilder(TsCheckTextFormatter text)
             $"{CommonUtil.FormatFileSize(result.BytesScanned / Math.Max(0.001, result.Elapsed.TotalSeconds))}/s");
         builder.AppendLine();
 
+        if (result.Timeline.Count > 0)
+        {
+            var timelineDuration = result.Timeline.Sum(item => item.DurationSeconds);
+            var timelinePackets = result.Timeline.Sum(item => item.TotalPacketCount);
+            var averageBitrate = timelinePackets * TsStreamAnalyzer.PacketSize * 8 /
+                                 Math.Max(0.001, timelineDuration);
+            var peakBitrate = result.Timeline.Max(item => item.TotalBitrate);
+            AppendSection(builder, strings.String_TsCheck_Report_BitrateTimeline);
+            AppendField(builder, strings.String_TsCheck_Report_ReferencePcr,
+                result.TimelineReferencePcrPid >= 0 ? $"0x{result.TimelineReferencePcrPid:X4}" : "-");
+            AppendField(builder, strings.String_TsCheck_Report_TimelineDuration,
+                TsCheckEvent.FormatTime(result.Timeline[^1].EndSeconds));
+            AppendField(builder, strings.String_TsCheck_Report_TimelineSamples,
+                result.Timeline.Count.ToString("N0"));
+            AppendField(builder, strings.String_TsCheck_Report_AverageBitrate,
+                string.Format(strings.String_TsCheck_Report_BitrateValue, averageBitrate / 1_000_000));
+            AppendField(builder, strings.String_TsCheck_Report_PeakBitrate,
+                string.Format(strings.String_TsCheck_Report_BitrateValue, peakBitrate / 1_000_000));
+            builder.AppendLine();
+        }
+
         AppendSection(builder, strings.String_TsCheck_Report_Programs);
         if (result.Programs.Count == 0)
         {

--- a/src/TSCutter.GUI/ViewModels/TsCheckWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsCheckWindowViewModel.cs
@@ -16,12 +16,20 @@ using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.ViewModels;
 
+public enum TsCheckViewMode
+{
+    Summary,
+    Details,
+    Timeline
+}
+
 public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewModel
 {
     private const int MaxUiEvents = 5_000;
     private readonly IDialogService _dialogService;
     private readonly TsCheckTextFormatter _text;
     private readonly Dictionary<int, TsCheckPidSummaryView> _pidSummaryRows = [];
+    private readonly List<TsCheckEvent> _liveTimelineEvents = [];
     private CancellationTokenSource? _cancellationTokenSource;
     private TsCheckResult? _result;
     private bool _isClosing;
@@ -32,15 +40,72 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
         _dialogService = dialogService;
         _text = new TsCheckTextFormatter();
         StatusText = _text.Strings.String_TsCheck_Status_Ready;
+        App.LocalizationService.LanguageChanged += OnLanguageChanged;
+        RebuildTimelineStreams();
     }
 
     public bool? DialogResult { get; }
     public string FilePath { get; set; } = string.Empty;
     public ObservableCollection<TsCheckEventView> Events { get; } = [];
     public ObservableCollection<TsCheckPidSummaryView> PidSummaries { get; } = [];
+    public ObservableCollection<TsCheckTimelineStreamView> TimelineStreams { get; } = [];
 
     [ObservableProperty]
-    private bool _isSummaryView = true;
+    [NotifyPropertyChangedFor(nameof(IsSummaryView))]
+    [NotifyPropertyChangedFor(nameof(IsDetailsView))]
+    [NotifyPropertyChangedFor(nameof(IsTimelineView))]
+    private TsCheckViewMode _viewMode = TsCheckViewMode.Summary;
+
+    public bool IsSummaryView
+    {
+        get => ViewMode == TsCheckViewMode.Summary;
+        set
+        {
+            if (value)
+                ViewMode = TsCheckViewMode.Summary;
+        }
+    }
+
+    public bool IsDetailsView
+    {
+        get => ViewMode == TsCheckViewMode.Details;
+        set
+        {
+            if (value)
+                ViewMode = TsCheckViewMode.Details;
+        }
+    }
+
+    public bool IsTimelineView
+    {
+        get => ViewMode == TsCheckViewMode.Timeline;
+        set
+        {
+            if (value)
+                ViewMode = TsCheckViewMode.Timeline;
+        }
+    }
+
+    [ObservableProperty]
+    private IReadOnlyList<TsCheckTimelineBucket> _timelineBuckets = Array.Empty<TsCheckTimelineBucket>();
+
+    [ObservableProperty]
+    private IReadOnlyList<TsCheckEvent> _timelineEvents = Array.Empty<TsCheckEvent>();
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(SelectedTimelinePid))]
+    [NotifyPropertyChangedFor(nameof(SelectedTimelineSeriesName))]
+    private TsCheckTimelineStreamView? _selectedTimelineStream;
+
+    public int SelectedTimelinePid => SelectedTimelineStream?.Pid ?? -1;
+    public string SelectedTimelineSeriesName =>
+        SelectedTimelineStream?.DisplayText ?? _text.Strings.String_TsCheck_Timeline_TotalTs;
+
+    [ObservableProperty]
+    private TsCheckEvent? _selectedTimelineEvent;
+
+    [ObservableProperty]
+    private TsCheckEventView? _selectedEventRow;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanStart))]
@@ -112,6 +177,12 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
         Events.Clear();
         PidSummaries.Clear();
         _pidSummaryRows.Clear();
+        _liveTimelineEvents.Clear();
+        TimelineBuckets = Array.Empty<TsCheckTimelineBucket>();
+        TimelineEvents = Array.Empty<TsCheckEvent>();
+        SelectedTimelineEvent = null;
+        SelectedEventRow = null;
+        RebuildTimelineStreams();
         Percent = 0;
         ErrorCount = 0;
         WarningCount = 0;
@@ -143,6 +214,9 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
             ElapsedText = result.Elapsed.ToString(@"hh\:mm\:ss\.fff");
             RebuildEvents();
             RebuildPidSummaries();
+            TimelineBuckets = result.Timeline.ToArray();
+            TimelineEvents = result.Events.ToArray();
+            RebuildTimelineStreams();
             ErrorCount = _result.ErrorCount;
             WarningCount = _result.WarningCount;
             Verdict = _result.Verdict;
@@ -178,10 +252,15 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
         ElapsedText = progress.Elapsed.ToString(@"hh\:mm\:ss\.fff");
         ErrorCount = progress.ErrorCount;
         WarningCount = progress.WarningCount;
+        TimelineBuckets = progress.Timeline;
         foreach (var pid in progress.Pids)
             UpdatePidSummary(pid, progress.PacketCount);
         if (progress.NewEvent is not null && Events.Count < MaxUiEvents)
+        {
             Events.Add(new TsCheckEventView(progress.NewEvent, _text));
+            _liveTimelineEvents.Add(progress.NewEvent);
+            TimelineEvents = _liveTimelineEvents.ToArray();
+        }
     }
 
     private void RebuildEvents()
@@ -218,6 +297,93 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
                 pid.SupplementaryStreamType, pid.Language,
                 pid.IsPcrPid, pid.IsPmtPid, false), _result.PacketCount);
         }
+    }
+
+    private void RebuildTimelineStreams()
+    {
+        var selectedPid = SelectedTimelineStream?.Pid ?? -1;
+        TimelineStreams.Clear();
+        TimelineStreams.Add(new TsCheckTimelineStreamView(
+            -1, _text.Strings.String_TsCheck_Timeline_TotalTs));
+
+        if (_result is not null)
+        {
+            var pids = new List<int>(_result.Pids.Keys);
+            pids.Sort();
+            foreach (var pidValue in pids)
+            {
+                var pid = _result.Pids[pidValue];
+                if (pid.PacketCount <= 0)
+                    continue;
+                var description = _text.FormatPidDescription(
+                    pid.Pid, pid.ProgramNumber, pid.StreamType, pid.MpegAudioLayer,
+                    pid.SupplementaryStreamType, pid.Language, pid.IsPcrPid, pid.IsPmtPid);
+                TimelineStreams.Add(new TsCheckTimelineStreamView(
+                    pid.Pid, $"{pid.PidText} · {description}"));
+            }
+        }
+
+        SelectedTimelineStream = TimelineStreams.Count > 0
+            ? FindTimelineStream(selectedPid) ?? TimelineStreams[0]
+            : null;
+    }
+
+    private TsCheckTimelineStreamView? FindTimelineStream(int pid)
+    {
+        foreach (var item in TimelineStreams)
+        {
+            if (item.Pid == pid)
+                return item;
+        }
+        return null;
+    }
+
+    partial void OnSelectedTimelineEventChanged(TsCheckEvent? value)
+    {
+        if (value is null)
+            return;
+        ViewMode = TsCheckViewMode.Details;
+        SelectEventRow(value);
+    }
+
+    private void SelectEventRow(TsCheckEvent value)
+    {
+        SelectedEventRow = null;
+        foreach (var item in Events)
+        {
+            if (ReferenceEquals(item.Item, value))
+            {
+                SelectedEventRow = item;
+                break;
+            }
+        }
+        if (SelectedEventRow is null && _result is not null)
+        {
+            // 时间轴可显示全部已保存异常；若目标超出详情表默认的 5,000 行上限，则临时置换末行以便定位。
+            if (Events.Count >= MaxUiEvents)
+                Events.RemoveAt(Events.Count - 1);
+            SelectedEventRow = new TsCheckEventView(value, _text, _result);
+            Events.Add(SelectedEventRow);
+        }
+    }
+
+    private void OnLanguageChanged()
+    {
+        RebuildTimelineStreams();
+        StatusText = IsScanning
+            ? _text.Strings.String_TsCheck_Status_Scanning
+            : _result is null
+                ? _text.Strings.String_TsCheck_Status_Ready
+                : _result.WasCancelled
+                    ? _text.Strings.String_TsCheck_Status_Cancelled
+                    : _text.Strings.String_TsCheck_Status_Completed;
+        if (_result is null)
+            return;
+        RebuildEvents();
+        RebuildPidSummaries();
+        if (SelectedTimelineEvent is { } selectedEvent)
+            SelectEventRow(selectedEvent);
+        VerdictText = _text.FormatVerdict(_result);
     }
 
     private void UpdatePidSummary(TsCheckPidProgress progress, long totalPacketCount)
@@ -272,11 +438,16 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
             return;
 
         _isClosing = true;
+        App.LocalizationService.LanguageChanged -= OnLanguageChanged;
         _scanGeneration++;
         _cancellationTokenSource?.Cancel();
         _result = null;
         Events.Clear();
         PidSummaries.Clear();
+        TimelineStreams.Clear();
+        _liveTimelineEvents.Clear();
+        TimelineBuckets = Array.Empty<TsCheckTimelineBucket>();
+        TimelineEvents = Array.Empty<TsCheckEvent>();
         _pidSummaryRows.Clear();
     }
 

--- a/src/TSCutter.GUI/Views/TsCheckWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsCheckWindow.axaml
@@ -5,6 +5,8 @@
         xmlns:viewModels="clr-namespace:TSCutter.GUI.ViewModels"
         xmlns:controls="clr-namespace:TSCutter.GUI.Controls"
         xmlns:local="clr-namespace:TSCutter.GUI"
+        xmlns:models="clr-namespace:TSCutter.GUI.Models"
+        xmlns:commonControls="clr-namespace:Classic.CommonControls;assembly=Classic.CommonControls.Avalonia"
         mc:Ignorable="d"
         x:Class="TSCutter.GUI.Views.TsCheckWindow"
         x:DataType="viewModels:TsCheckWindowViewModel"
@@ -100,7 +102,9 @@
                 <RadioButton GroupName="TsCheckView" Content="{DynamicResource String.TsCheck.View.Summary}"
                              IsChecked="{Binding IsSummaryView, Mode=TwoWay}" />
                 <RadioButton GroupName="TsCheckView" Content="{DynamicResource String.TsCheck.View.Details}"
-                             IsChecked="{Binding IsSummaryView, Mode=TwoWay, Converter={x:Static local:App.InverseBoolConverter}}" />
+                             IsChecked="{Binding IsDetailsView, Mode=TwoWay}" />
+                <RadioButton GroupName="TsCheckView" Content="{DynamicResource String.TsCheck.View.Timeline}"
+                             IsChecked="{Binding IsTimelineView, Mode=TwoWay}" />
             </StackPanel>
         </Grid>
 
@@ -146,7 +150,9 @@
         </DataGrid>
 
         <DataGrid Grid.Row="3" ItemsSource="{Binding Events}" IsReadOnly="True" AutoGenerateColumns="False"
-                  IsVisible="{Binding IsSummaryView, Converter={x:Static local:App.InverseBoolConverter}}"
+                  x:Name="DetailsGrid"
+                  IsVisible="{Binding IsDetailsView}"
+                  SelectedItem="{Binding SelectedEventRow, Mode=TwoWay}"
                   GridLinesVisibility="All" CanUserResizeColumns="True"
                   HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Auto"
                   ScrollViewer.HorizontalScrollBarVisibility="Visible"
@@ -162,6 +168,47 @@
                 <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Description}" Binding="{Binding Message}" Width="420" />
             </DataGrid.Columns>
         </DataGrid>
+
+        <Grid Grid.Row="3" IsVisible="{Binding IsTimelineView}" RowDefinitions="Auto,*" RowSpacing="6">
+            <Grid Grid.Row="0" ColumnDefinitions="Auto,360,*" ColumnSpacing="8">
+                <TextBlock Grid.Column="0" Text="{DynamicResource String.TsCheck.Timeline.Stream}"
+                           VerticalAlignment="Center" />
+                <ComboBox Grid.Column="1" ItemsSource="{Binding TimelineStreams}"
+                          SelectedItem="{Binding SelectedTimelineStream, Mode=TwoWay}">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate x:DataType="models:TsCheckTimelineStreamView">
+                            <TextBlock Text="{Binding DisplayText}" TextTrimming="CharacterEllipsis" />
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
+                <TextBlock Grid.Column="2" Text="{DynamicResource String.TsCheck.Timeline.Hint}"
+                           Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}"
+                           VerticalAlignment="Center" TextAlignment="Right" TextWrapping="Wrap" />
+            </Grid>
+            <ClassicBorderDecorator Grid.Row="1" BorderThickness="2" BorderStyle="Sunken">
+                <controls:TsCheckTimeline Buckets="{Binding TimelineBuckets}"
+                                          EventSelected="Timeline_OnEventSelected"
+                                          Events="{Binding TimelineEvents}"
+                                          SelectedPid="{Binding SelectedTimelinePid}"
+                                          SeriesName="{Binding SelectedTimelineSeriesName}"
+                                          SelectedEvent="{Binding SelectedTimelineEvent, Mode=TwoWay}"
+                                          BackgroundBrush="{DynamicResource {x:Static commonControls:SystemColors.WindowColorKey}}"
+                                          PrimaryBrush="{DynamicResource TsCheckPacketShareBrush}"
+                                          SecondaryBrush="{DynamicResource {x:Static commonControls:SystemColors.GrayTextColorKey}}"
+                                          GridBrush="{DynamicResource {x:Static commonControls:SystemColors.GrayTextColorKey}}"
+                                          TextBrush="{DynamicResource {x:Static commonControls:SystemColors.WindowTextColorKey}}"
+                                          ErrorBrush="{DynamicResource TsCheckErrorCellForegroundBrush}"
+                                          WarningBrush="{DynamicResource TsCheckWarningCellForegroundBrush}"
+                                          TooltipBackgroundBrush="{DynamicResource {x:Static commonControls:SystemColors.InfoColorKey}}"
+                                          TooltipTextBrush="{DynamicResource {x:Static commonControls:SystemColors.InfoTextColorKey}}"
+                                          TooltipBorderBrush="{DynamicResource {x:Static commonControls:SystemColors.WindowFrameColorKey}}"
+                                          TotalText="{DynamicResource String.TsCheck.Timeline.TotalTs}"
+                                          NoDataText="{DynamicResource String.TsCheck.Timeline.NoData}"
+                                          ErrorText="{DynamicResource String.TsCheck.Severity.Error}"
+                                          WarningText="{DynamicResource String.TsCheck.Severity.Warning}"
+                                          MinHeight="200" />
+            </ClassicBorderDecorator>
+        </Grid>
 
         <StackPanel Grid.Row="4" Margin="0,10,0,0" Orientation="Horizontal" HorizontalAlignment="Right" Spacing="8">
             <Button Content="{DynamicResource String.TsCheck.Start}" Command="{Binding StartCommand}" Width="100" />

--- a/src/TSCutter.GUI/Views/TsCheckWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/TsCheckWindow.axaml.cs
@@ -1,5 +1,7 @@
 using System;
+using Avalonia.Threading;
 using Classic.Avalonia.Theme;
+using TSCutter.GUI.Controls;
 using TSCutter.GUI.ViewModels;
 
 namespace TSCutter.GUI.Views;
@@ -23,5 +25,20 @@ public partial class TsCheckWindow : ClassicWindow
     {
         if (DataContext is TsCheckWindowViewModel viewModel)
             viewModel.OnClosed();
+    }
+
+    private void Timeline_OnEventSelected(object? sender, TsCheckTimelineEventSelectedEventArgs eventArgs)
+    {
+        if (DataContext is TsCheckWindowViewModel viewModel)
+        {
+            viewModel.SelectedTimelineEvent = eventArgs.Item;
+            viewModel.ViewMode = TsCheckViewMode.Details;
+        }
+        // 视图切换完成后再滚动，否则详情表格尚未参与布局，无法可靠定位选中行。
+        Dispatcher.UIThread.Post(() =>
+        {
+            if (DataContext is TsCheckWindowViewModel { SelectedEventRow: { } row })
+                DetailsGrid.ScrollIntoView(row, null);
+        }, DispatcherPriority.Loaded);
     }
 }


### PR DESCRIPTION
## Overview

Add a bitrate and anomaly timeline to TS Quick Check, making it easier to locate bitrate fluctuations, packet loss, and timestamp issues.

## Changes

- Add total TS and per-PID bitrate curves
- Collect low-overhead PCR-based samples during the existing single-pass scan
- Display errors and warnings as red and yellow timeline markers
- Show time, bitrate, and anomaly status on hover
- Open and locate the corresponding detail when a marker is clicked
- Automatically compact samples for long recordings to limit memory usage
- Include reference PCR, average bitrate, and peak bitrate in text reports
- Match the existing Classic UI and support light and dark themes
- Add English, Simplified Chinese, and Traditional Chinese localization

## Performance

The timeline does not perform deep decoding or a second scan. The packet hot path only increments counters, while bounded sampling and custom drawing keep memory and UI overhead controlled.

## Validation

- Debug build passed
- Release build passed
- Verified bitrate curves, anomaly markers, and scan verdicts with both normal and problematic TS files

---

## 概述

为 TS 快速检查新增码率与异常时间轴视图，方便直观定位码率波动、丢包及时间戳异常集中的时间段。

## 主要改动

- 新增总 TS 码率及各 PID 码率曲线
- 基于 PCR 在现有单遍扫描中进行低开销采样
- 使用红色和黄色标记错误与警告
- 支持悬停查看时间、码率和异常状态
- 支持点击异常标记并跳转到对应详情
- 长时间录制自动合并采样，限制内存占用
- 文本报告增加参考 PCR、平均码率及峰值码率
- 适配 Classic 界面风格及深浅色主题
- 补充简体中文、繁体中文和英文文本

## 性能

时间轴不进行深度解码或二次扫描。逐包热路径仅执行整数计数，并通过固定采样上限及自绘控件控制内存和界面开销。

## 验证

- Debug 构建通过
- Release 构建通过
- 已使用正常及异常 TS 文件验证码率、异常标记和检查结论