### PR TITLE
Fix cascading quick-check errors caused by TEI packets

### DIFF
--- a/src/TSCutter.GUI.Tests/TSCutter.GUI.Tests.csproj
+++ b/src/TSCutter.GUI.Tests/TSCutter.GUI.Tests.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+    <PropertyGroup>
+        <TargetFramework>net10.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+        <IsTestProject>true</IsTestProject>
+    </PropertyGroup>
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+    <ItemGroup>
+        <ProjectReference Include="../TSCutter.GUI/TSCutter.GUI.csproj" />
+    </ItemGroup>
+</Project>

--- a/src/TSCutter.GUI.Tests/TsStreamAnalyzerTests.cs
+++ b/src/TSCutter.GUI.Tests/TsStreamAnalyzerTests.cs
@@ -1,0 +1,150 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using TSCutter.GUI.Models;
+using TSCutter.GUI.Services;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public sealed class TsStreamAnalyzerTests
+{
+    [Fact]
+    public async Task TransportErrorPacketsDoNotProduceCascadingHeaderClockOrContinuityErrors()
+    {
+        var packets = new List<byte[]>
+        {
+            CreatePacket(0x0100, 0, pcrBase: 90_000),
+            CreatePacket(0x0100, 1, pcrBase: 93_000),
+            CreatePacket(0x0100, 2),
+            CreatePacket(0x0100, 3),
+            CreatePacket(0x0100, 12, transportError: true, adaptationControl: 0),
+            CreatePacket(0x0100, 14, transportError: true, pcrBase: 4_000_000_000),
+            CreatePacket(0x0100, 6, pcrBase: 108_000),
+            CreatePacket(0x0100, 7)
+        };
+
+        var result = await AnalyzeAsync(packets);
+
+        Assert.Equal(2, Count(result, TsCheckEventType.TransportError));
+        Assert.Equal(0, Count(result, TsCheckEventType.ContinuityGap));
+        Assert.Equal(0, Count(result, TsCheckEventType.InvalidPacketHeader));
+        Assert.Equal(0, Count(result, TsCheckEventType.SyncLoss));
+        Assert.Equal(0, Count(result, TsCheckEventType.PcrBackward));
+        Assert.Equal(0, Count(result, TsCheckEventType.PcrJump));
+    }
+
+    [Fact]
+    public async Task ContinuityGapWithoutTransportErrorIsStillReported()
+    {
+        var packets = new[]
+        {
+            CreatePacket(0x0101, 0),
+            CreatePacket(0x0101, 1),
+            CreatePacket(0x0101, 2),
+            CreatePacket(0x0101, 4),
+            CreatePacket(0x0101, 5),
+            CreatePacket(0x0101, 6)
+        };
+
+        var result = await AnalyzeAsync(packets);
+
+        Assert.Equal(1, Count(result, TsCheckEventType.ContinuityGap));
+    }
+
+    [Fact]
+    public async Task ReliablePcrJumpAfterTransportErrorIsStillReported()
+    {
+        var packets = new[]
+        {
+            CreatePacket(0x0102, 0, pcrBase: 90_000),
+            CreatePacket(0x0102, 1, pcrBase: 93_000),
+            CreatePacket(0x0102, 2),
+            CreatePacket(0x0102, 3),
+            CreatePacket(0x0102, 4, transportError: true),
+            CreatePacket(0x0102, 5, pcrBase: 2_000_000),
+            CreatePacket(0x0102, 6)
+        };
+
+        var result = await AnalyzeAsync(packets);
+
+        Assert.Equal(1, Count(result, TsCheckEventType.TransportError));
+        Assert.Equal(1, Count(result, TsCheckEventType.PcrJump));
+    }
+
+    [Fact]
+    public async Task InterleavedTransportErrorsAreMergedPerPid()
+    {
+        var packets = new[]
+        {
+            CreatePacket(0x0100, 0),
+            CreatePacket(0x0100, 1),
+            CreatePacket(0x0100, 2, transportError: true),
+            CreatePacket(0x0101, 0, transportError: true),
+            CreatePacket(0x0100, 3, transportError: true),
+            CreatePacket(0x0101, 1, transportError: true),
+            CreatePacket(0x0100, 4),
+            CreatePacket(0x0101, 2)
+        };
+
+        var result = await AnalyzeAsync(packets);
+        var events = result.Events.Where(item => item.Type == TsCheckEventType.TransportError).ToArray();
+
+        Assert.Equal(4, events.Sum(item => item.Occurrences));
+        Assert.Equal(2, events.Length);
+        Assert.Equal(2, events.Single(item => item.Pid == 0x0100).Occurrences);
+        Assert.Equal(2, events.Single(item => item.Pid == 0x0101).Occurrences);
+    }
+
+    private static int Count(TsCheckResult result, TsCheckEventType type) => result.Events
+        .Where(item => item.Type == type)
+        .Sum(item => item.Occurrences);
+
+    private static async Task<TsCheckResult> AnalyzeAsync(IEnumerable<byte[]> packets)
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"ts-check-{Guid.NewGuid():N}.ts");
+        try
+        {
+            await using (var stream = new FileStream(path, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                foreach (var packet in packets)
+                    await stream.WriteAsync(packet);
+            }
+            return await new TsStreamAnalyzer().AnalyzeAsync(path);
+        }
+        finally
+        {
+            File.Delete(path);
+        }
+    }
+
+    private static byte[] CreatePacket(
+        int pid,
+        int continuityCounter,
+        bool transportError = false,
+        int adaptationControl = 1,
+        long? pcrBase = null)
+    {
+        var packet = new byte[TsStreamAnalyzer.PacketSize];
+        Array.Fill(packet, (byte)0x55);
+        packet[0] = 0x47;
+        packet[1] = (byte)((transportError ? 0x80 : 0) | ((pid >> 8) & 0x1F));
+        packet[2] = (byte)pid;
+        packet[3] = (byte)((adaptationControl << 4) | (continuityCounter & 0x0F));
+        if (pcrBase is not { } pcr)
+            return packet;
+
+        packet[3] = (byte)(0x30 | (continuityCounter & 0x0F));
+        packet[4] = 7;
+        packet[5] = 0x10;
+        packet[6] = (byte)(pcr >> 25);
+        packet[7] = (byte)(pcr >> 17);
+        packet[8] = (byte)(pcr >> 9);
+        packet[9] = (byte)(pcr >> 1);
+        packet[10] = (byte)(((pcr & 1) << 7) | 0x7E);
+        packet[11] = 0;
+        return packet;
+    }
+}

--- a/src/TSCutter.GUI.sln
+++ b/src/TSCutter.GUI.sln
@@ -4,6 +4,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TSCutter.GUI", "TSCutter.GU
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TSCutter.GUI.Generators", "TSCutter.GUI.Generators\TSCutter.GUI.Generators.csproj", "{7EF1585C-04F0-4FC6-8307-7B1B21B88058}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TSCutter.GUI.Tests", "TSCutter.GUI.Tests\TSCutter.GUI.Tests.csproj", "{F21B6DD4-76B9-4D53-89C9-50735583EF2A}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -18,5 +20,9 @@ Global
 		{7EF1585C-04F0-4FC6-8307-7B1B21B88058}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EF1585C-04F0-4FC6-8307-7B1B21B88058}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EF1585C-04F0-4FC6-8307-7B1B21B88058}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F21B6DD4-76B9-4D53-89C9-50735583EF2A}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F21B6DD4-76B9-4D53-89C9-50735583EF2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F21B6DD4-76B9-4D53-89C9-50735583EF2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F21B6DD4-76B9-4D53-89C9-50735583EF2A}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/src/TSCutter.GUI/Services/TsStreamAnalyzer.cs
+++ b/src/TSCutter.GUI/Services/TsStreamAnalyzer.cs
@@ -32,6 +32,8 @@ public sealed class TsStreamAnalyzer
     private readonly Dictionary<int, int> _streamPidPrograms = [];
     private readonly Dictionary<int, int> _pcrPidPrograms = [];
     private readonly Dictionary<int, ProgramClockState> _programClocks = [];
+    private readonly Dictionary<(TsCheckSeverity Severity, TsCheckEventType Type, int Pid), TsCheckEvent>
+        _lastMergeableEvents = [];
     private TsCheckResult _result = null!;
     private IProgress<TsCheckProgress>? _progress;
     private Stopwatch _stopwatch = null!;
@@ -161,6 +163,7 @@ public sealed class TsStreamAnalyzer
         _streamPidPrograms.Clear();
         _pcrPidPrograms.Clear();
         _programClocks.Clear();
+        _lastMergeableEvents.Clear();
         _result = new TsCheckResult
         {
             FilePath = filePath,
@@ -296,19 +299,31 @@ public sealed class TsStreamAnalyzer
             state.TimelineIntervalPacketCount++;
             _timelineIntervalPacketCount++;
         }
-        if (hasPayload)
-            state.Summary.PayloadPacketCount++;
 
         if (transportError)
         {
-            state.DiscardPes();
+            var eventTime = GetPacketEventTime(state);
+            // TEI 表示该 TS 包含有不可纠正错误，除同步字节和 TEI 本身外，PID、CC、
+            // adaptation field 与 payload 都可能已经损坏。记录主错误后立即短路，避免
+            // 同一个坏包继续制造 CC、PCR、PES 和非法 adaptation field 等级联误报。
+            state.DiscardUnreliablePayload();
             if (_psiAssemblers.TryGetValue(pid, out var damagedAssembler))
                 damagedAssembler.DiscardUntilPayloadStart();
+            if ((_streamPidPrograms.TryGetValue(pid, out var damagedProgramNumber) ||
+                 _pcrPidPrograms.TryGetValue(pid, out damagedProgramNumber)) &&
+                _programClocks.TryGetValue(damagedProgramNumber, out var damagedClock))
+            {
+                damagedClock.ResetSync();
+            }
             state.Summary.TransportErrors++;
             if (!_options.InventoryOnly)
                 AddEvent(TsCheckSeverity.Error, TsCheckEventType.TransportError, pid, _packetIndex, fileOffset,
-                    TsCheckMessageCode.TransportError, [], GetPacketEventTime(state), true);
+                    TsCheckMessageCode.TransportError, [], eventTime, true);
+            return;
         }
+
+        if (hasPayload)
+            state.Summary.PayloadPacketCount++;
 
         if (adaptationControl == 0)
         {
@@ -1295,11 +1310,12 @@ public sealed class TsStreamAnalyzer
 
         TsCheckEvent? item = null;
         var isNewEvent = false;
-        if (_result.Events.Count > 0)
+        var mergeKey = (severity, type, pid);
+        if (_lastMergeableEvents.TryGetValue(mergeKey, out var previous))
         {
-            var previous = _result.Events[^1];
-            // 邻近同类异常合并为一个区间，避免严重坏流生成海量 UI 行和报告文本。
-            if (previous.Type == type && previous.Pid == pid && packetIndex - previous.EndPacket <= 256)
+            // 同一损坏区域内的各 PID 会交错出现。按“级别、类型、PID”分别记住最近事件，
+            // 可跨过其他 PID 的行继续合并，避免连续 TEI 尾段被拆成上千条详情。
+            if (packetIndex - previous.EndPacket <= 256)
             {
                 previous.EndPacket = packetIndex;
                 previous.Occurrences++;
@@ -1332,6 +1348,7 @@ public sealed class TsStreamAnalyzer
                 MessageArguments = messageArguments
             };
             _result.Events.Add(item);
+            _lastMergeableEvents[mergeKey] = item;
             isNewEvent = true;
         }
 
@@ -1732,6 +1749,16 @@ public sealed class TsStreamAnalyzer
         public double TimelineBucketPacketCount;
 
         public void ResetContinuity() => HasContinuity = false;
+
+        public void DiscardUnreliablePayload()
+        {
+            // TEI 包不能作为下一包的连续性基线，也不能保留跨包 PES/音频探测的半成品；
+            // 时间戳基线仍保留，使恢复后的可靠 PTS/PCR 若确有跳变仍能被正常报告。
+            ResetContinuity();
+            PesHeaderLength = 0;
+            DiscardPes();
+            MpegAudioProbeTailLength = 0;
+        }
 
         public void ResetTimestamps()
         {


### PR DESCRIPTION
## Overview

Fixes excessive cascading reports in TS Quick Check when damaged transport packets carry the Transport Error Indicator (TEI) but their untrusted headers and payloads continue to be analyzed.

## Changes

- Stop processing a packet immediately after reporting its TEI error
- Discard continuity, PES, PSI, and A/V synchronization state affected by the damaged packet
- Prevent derived continuity, PCR, PES, and invalid adaptation-field errors
- Preserve timestamp baselines so genuine PCR jumps in subsequent reliable data are still detected
- Merge interleaved errors by PID and damaged region to reduce duplicate detail rows and report entries
- Add Chinese comments around the critical processing logic
- Add a TS analyzer test project with focused regression coverage

## Validation

- Verified that TEI packets do not generate cascading continuity, PCR, or header errors
- Verified that ordinary continuity gaps are still reported
- Verified that genuine PCR jumps after a TEI packet remain detectable
- Verified per-PID aggregation for interleaved TEI errors
- Scanned a real damaged transport stream sample
- Confirmed successful Debug and Release builds

---

## 概述

修复快速检测在遇到设置了传输错误指示符（TEI）的损坏 TS 包后，继续解析不可信数据并产生大量级联误报的问题。

## 主要改动

- TEI 包记录传输错误后立即停止进一步解析
- 丢弃受损包关联的连续性、PES、PSI 和音视频同步状态
- 避免产生派生的 CC、PCR、PES 及非法 adaptation field 错误
- 保留时间戳基线，确保恢复后的真实 PCR 跳变仍能被检测
- 按 PID 和异常区域聚合交错出现的同类错误，减少详情表和文本报告中的重复记录
- 为关键处理逻辑补充中文注释
- 新增 TS 分析器测试项目和相关回归测试

## 测试

- 验证 TEI 包不会产生连续性、PCR 或包头级联错误
- 验证普通连续性缺口仍会正常报告
- 验证 TEI 后可靠数据中的真实 PCR 跳变仍会报告
- 验证多个 PID 交错出现的 TEI 错误能够分别聚合
- 使用实际损坏样本完成扫描验证
- Debug 和 Release 构建通过