### PR TITLE
Support multiple concurrent tool windows

### DIFF
--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -265,7 +265,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var dialogViewModel = _dialogService.CreateViewModel<RawCutterWindowViewModel>();
         dialogViewModel.Initialize(filePath);
-        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+        _dialogService.Show(this, dialogViewModel);
     }
 
     [RelayCommand]
@@ -282,7 +282,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var dialogViewModel = _dialogService.CreateViewModel<TsCheckWindowViewModel>();
         dialogViewModel.FilePath = result[0].LocalPath;
-        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+        _dialogService.Show(this, dialogViewModel);
     }
 
     [RelayCommand]
@@ -299,7 +299,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var dialogViewModel = _dialogService.CreateViewModel<TsTimelineRepairWindowViewModel>();
         dialogViewModel.Initialize(result[0].LocalPath);
-        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+        _dialogService.Show(this, dialogViewModel);
     }
 
     [RelayCommand]
@@ -316,7 +316,7 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var dialogViewModel = _dialogService.CreateViewModel<TsFilterWindowViewModel>();
         dialogViewModel.FilePath = result[0].LocalPath;
-        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+        _dialogService.Show(this, dialogViewModel);
     }
 
     [RelayCommand]
@@ -333,14 +333,14 @@ public partial class MainWindowViewModel : ViewModelBase
 
         var dialogViewModel = _dialogService.CreateViewModel<TsServiceFilterWindowViewModel>();
         dialogViewModel.FilePath = result[0].LocalPath;
-        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+        _dialogService.Show(this, dialogViewModel);
     }
 
     [RelayCommand]
-    private async Task TsMultiSourceRepairClickAsync()
+    private void TsMultiSourceRepairClick()
     {
         var dialogViewModel = _dialogService.CreateViewModel<TsMultiSourceRepairWindowViewModel>();
-        await _dialogService.ShowDialogAsync(this, dialogViewModel);
+        _dialogService.Show(this, dialogViewModel);
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]

--- a/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
@@ -24,14 +24,19 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
     private bool _isOutputting; // 防止输出命令重入
     private CancellationTokenSource? _statusCts; // 状态消息自动消失计时
     private bool _syncingSlider; // 防止滑块与输入框循环同步
+    private bool _isClosing;
 
     public RawCutterWindowViewModel(IDialogService dialogService)
     {
         _dialogService = dialogService;
+        App.LocalizationService.LanguageChanged += OnLanguageChanged;
     }
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WindowTitle))]
     private string _filePath = string.Empty;
+
+    public string WindowTitle => $"{LocalizationManager.Instance.String_RawCutter_Title} - {Path.GetFileName(FilePath)}";
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(SyncInfo))]
@@ -361,8 +366,23 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
 
     public void OnClosing(CancelEventArgs e)
     {
-        _statusCts?.Cancel();
+        ReleaseForClose();
     }
+
+    public void OnClosed() => ReleaseForClose();
+
+    private void ReleaseForClose()
+    {
+        if (_isClosing)
+            return;
+        _isClosing = true;
+        App.LocalizationService.LanguageChanged -= OnLanguageChanged;
+        _statusCts?.Cancel();
+        _statusCts?.Dispose();
+        _statusCts = null;
+    }
+
+    private void OnLanguageChanged() => OnPropertyChanged(nameof(WindowTitle));
 
     public event Action? RequestClose;
 

--- a/src/TSCutter.GUI/ViewModels/TsCheckWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsCheckWindowViewModel.cs
@@ -46,6 +46,7 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
 
     public bool? DialogResult { get; }
     public string FilePath { get; set; } = string.Empty;
+    public string WindowTitle => $"{_text.Strings.String_TsCheck_Title} - {Path.GetFileName(FilePath)}";
     public ObservableCollection<TsCheckEventView> Events { get; } = [];
     public ObservableCollection<TsCheckPidSummaryView> PidSummaries { get; } = [];
     public ObservableCollection<TsCheckTimelineStreamView> TimelineStreams { get; } = [];
@@ -410,6 +411,7 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
 
     private void OnLanguageChanged()
     {
+        OnPropertyChanged(nameof(WindowTitle));
         RebuildTimelineStreams();
         OnPropertyChanged(nameof(TimelineNoticeText));
         StatusText = IsScanning

--- a/src/TSCutter.GUI/ViewModels/TsFilterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsFilterWindowViewModel.cs
@@ -34,10 +34,12 @@ public partial class TsFilterWindowViewModel : ViewModelBase, IModalDialogViewMo
     {
         _dialogService = dialogService;
         StatusText = LocalizationManager.Instance.String_TsFilter_Status_Ready;
+        App.LocalizationService.LanguageChanged += OnLanguageChanged;
     }
 
     public bool? DialogResult { get; }
     public string FilePath { get; set; } = string.Empty;
+    public string WindowTitle => $"{LocalizationManager.Instance.String_TsFilter_Title} - {Path.GetFileName(FilePath)}";
     public ObservableCollection<TsFilterPidItem> Pids { get; } = [];
     public string FileSizeText => File.Exists(FilePath)
         ? CommonUtil.FormatFileSize(new FileInfo(FilePath).Length)
@@ -385,6 +387,7 @@ public partial class TsFilterWindowViewModel : ViewModelBase, IModalDialogViewMo
         if (_isClosing)
             return;
         _isClosing = true;
+        App.LocalizationService.LanguageChanged -= OnLanguageChanged;
         _generation++;
         _cancellationTokenSource?.Cancel();
         foreach (var row in _allPids)
@@ -394,4 +397,6 @@ public partial class TsFilterWindowViewModel : ViewModelBase, IModalDialogViewMo
         _catalog = null;
         _plan = null;
     }
+
+    private void OnLanguageChanged() => OnPropertyChanged(nameof(WindowTitle));
 }

--- a/src/TSCutter.GUI/ViewModels/TsMultiSourceRepairWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsMultiSourceRepairWindowViewModel.cs
@@ -53,7 +53,12 @@ public partial class TsMultiSourceRepairWindowViewModel : ViewModelBase, IModalD
 
     [ObservableProperty]
     [NotifyCanExecuteChangedFor(nameof(AnalyzeCommand))]
+    [NotifyPropertyChangedFor(nameof(WindowTitle))]
     private TsRepairSourceItem? _selectedReference;
+
+    public string WindowTitle => SelectedReference is null
+        ? _text.Strings.String_TsRepair_Title
+        : $"{_text.Strings.String_TsRepair_Title} - {SelectedReference.FileName}";
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanAnalyze))]
@@ -903,6 +908,7 @@ public partial class TsMultiSourceRepairWindowViewModel : ViewModelBase, IModalD
 
     private void OnLanguageChanged()
     {
+        OnPropertyChanged(nameof(WindowTitle));
         OnPropertyChanged(nameof(TimelineNormalizationNote));
         OnPropertyChanged(nameof(LargeGapMatchButtonText));
         if (_analysis is not null)

--- a/src/TSCutter.GUI/ViewModels/TsServiceFilterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsServiceFilterWindowViewModel.cs
@@ -32,10 +32,12 @@ public partial class TsServiceFilterWindowViewModel : ViewModelBase, IModalDialo
     {
         _dialogService = dialogService;
         StatusText = LocalizationManager.Instance.String_TsServiceFilter_Status_Ready;
+        App.LocalizationService.LanguageChanged += OnLanguageChanged;
     }
 
     public bool? DialogResult { get; }
     public string FilePath { get; set; } = string.Empty;
+    public string WindowTitle => $"{LocalizationManager.Instance.String_TsServiceFilter_Title} - {Path.GetFileName(FilePath)}";
     public ObservableCollection<TsServiceFilterItem> Services { get; } = [];
     public string FileSizeText => File.Exists(FilePath)
         ? CommonUtil.FormatFileSize(new FileInfo(FilePath).Length)
@@ -413,6 +415,7 @@ public partial class TsServiceFilterWindowViewModel : ViewModelBase, IModalDialo
         if (_isClosing)
             return;
         _isClosing = true;
+        App.LocalizationService.LanguageChanged -= OnLanguageChanged;
         _generation++;
         _cancellationTokenSource?.Cancel();
         foreach (var row in Services)
@@ -420,4 +423,6 @@ public partial class TsServiceFilterWindowViewModel : ViewModelBase, IModalDialo
         Services.Clear();
         _catalog = null;
     }
+
+    private void OnLanguageChanged() => OnPropertyChanged(nameof(WindowTitle));
 }

--- a/src/TSCutter.GUI/ViewModels/TsTimelineRepairWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsTimelineRepairWindowViewModel.cs
@@ -41,7 +41,10 @@ public partial class TsTimelineRepairWindowViewModel : ViewModelBase, IModalDial
     public ObservableCollection<TsTimelineRepairIssueView> Issues { get; } = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(WindowTitle))]
     private string _filePath = string.Empty;
+
+    public string WindowTitle => $"{LocalizationManager.Instance.String_TsTimelineRepair_Title} - {Path.GetFileName(FilePath)}";
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanRepair))]
@@ -321,6 +324,7 @@ public partial class TsTimelineRepairWindowViewModel : ViewModelBase, IModalDial
 
     private void OnLanguageChanged()
     {
+        OnPropertyChanged(nameof(WindowTitle));
         RebuildIssueRows();
         if (_analysis is not null)
         {

--- a/src/TSCutter.GUI/Views/RawCutterWindow.axaml
+++ b/src/TSCutter.GUI/Views/RawCutterWindow.axaml
@@ -14,7 +14,7 @@
         CanMaximize="False"
         WindowStartupLocation="CenterOwner"
         x:DataType="viewModels:RawCutterWindowViewModel"
-        Title="{DynamicResource String.RawCutter.Title}">
+        Title="{Binding WindowTitle}">
 
     <Window.Styles>
         <Style Selector="TextBlock.Label">

--- a/src/TSCutter.GUI/Views/RawCutterWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/RawCutterWindow.axaml.cs
@@ -10,6 +10,7 @@ public partial class RawCutterWindow : ClassicWindow
     {
         InitializeComponent();
         Loaded += OnInitialized;
+        Closed += OnClosed;
     }
 
     private void OnInitialized(object? sender, EventArgs e)
@@ -18,5 +19,14 @@ public partial class RawCutterWindow : ClassicWindow
         {
             vm.RequestClose += Close;
         }
+    }
+
+    private void OnClosed(object? sender, EventArgs e)
+    {
+        if (DataContext is not RawCutterWindowViewModel viewModel)
+            return;
+
+        viewModel.RequestClose -= Close;
+        viewModel.OnClosed();
     }
 }

--- a/src/TSCutter.GUI/Views/TsCheckWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsCheckWindow.axaml
@@ -10,7 +10,7 @@
         mc:Ignorable="d"
         x:Class="TSCutter.GUI.Views.TsCheckWindow"
         x:DataType="viewModels:TsCheckWindowViewModel"
-        Title="{DynamicResource String.TsCheck.Title}"
+        Title="{Binding WindowTitle}"
         Width="900" Height="580"
         MinWidth="720" MinHeight="460"
         WindowStartupLocation="CenterOwner">

--- a/src/TSCutter.GUI/Views/TsFilterWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsFilterWindow.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         x:Class="TSCutter.GUI.Views.TsFilterWindow"
         x:DataType="viewModels:TsFilterWindowViewModel"
-        Title="{DynamicResource String.TsFilter.Title}"
+        Title="{Binding WindowTitle}"
         Width="860" Height="560" MinWidth="700" MinHeight="440"
         WindowStartupLocation="CenterOwner">
     <Grid Margin="12" RowDefinitions="Auto,Auto,*,Auto" RowSpacing="8">

--- a/src/TSCutter.GUI/Views/TsMultiSourceRepairWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsMultiSourceRepairWindow.axaml
@@ -9,7 +9,7 @@
         mc:Ignorable="d"
         x:Class="TSCutter.GUI.Views.TsMultiSourceRepairWindow"
         x:DataType="viewModels:TsMultiSourceRepairWindowViewModel"
-        Title="{DynamicResource String.TsRepair.Title}"
+        Title="{Binding WindowTitle}"
         Width="900" Height="580" MinWidth="720" MinHeight="460"
         WindowStartupLocation="CenterOwner">
     <Window.Styles>

--- a/src/TSCutter.GUI/Views/TsServiceFilterWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsServiceFilterWindow.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         x:Class="TSCutter.GUI.Views.TsServiceFilterWindow"
         x:DataType="viewModels:TsServiceFilterWindowViewModel"
-        Title="{DynamicResource String.TsServiceFilter.Title}"
+        Title="{Binding WindowTitle}"
         Width="860" Height="560" MinWidth="720" MinHeight="440"
         WindowStartupLocation="CenterOwner">
     <Grid Margin="12" RowDefinitions="Auto,24,Auto,*,Auto" RowSpacing="8">

--- a/src/TSCutter.GUI/Views/TsTimelineRepairWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsTimelineRepairWindow.axaml
@@ -6,7 +6,7 @@
         mc:Ignorable="d"
         x:Class="TSCutter.GUI.Views.TsTimelineRepairWindow"
         x:DataType="viewModels:TsTimelineRepairWindowViewModel"
-        Title="{DynamicResource String.TsTimelineRepair.Title}"
+        Title="{Binding WindowTitle}"
         Width="900" Height="580" MinWidth="720" MinHeight="460"
         WindowStartupLocation="CenterOwner">
 


### PR DESCRIPTION
## Overview

Convert the independent tools under the Tools menu to modeless windows, allowing users to open and operate multiple tool instances at the same time, such as scanning and comparing different TS files concurrently.

## Changes

- Allow multiple Raw Cutter windows
- Allow multiple TS Quick Check scans
- Allow multiple Timeline Repair windows
- Allow multiple PID and service filter windows
- Allow multiple Multi-source Repair windows
- Keep Settings and tool-specific save, confirmation, and output flows modal
- Include the source file name in single-file tool window titles
- Show the selected reference source in Multi-source Repair window titles
- Improve task cancellation, event cleanup, and resource release when windows close

## Validation

- Debug build passed
- Release build passed
- All 15 automated tests passed
- Release startup smoke test passed

---

## 概述

将工具菜单中的独立功能改为非模态窗口，使用户可以同时打开和操作多个工具实例，例如并行扫描和比较不同的 TS 文件。

## 主要改动

- 支持同时打开多个原始流截取窗口
- 支持同时运行多个 TS 快速检查
- 支持同时打开多个时间轴修复窗口
- 支持多个 PID 和服务过滤窗口
- 支持多个多源修复窗口
- 设置页及工具内部的保存、确认和输出流程继续保持模态
- 单文件工具窗口标题增加源文件名
- 多源修复窗口标题显示选定的参考源
- 完善窗口关闭时的任务取消、事件解绑和资源清理

## 验证

- Debug 构建通过
- Release 构建通过
- 15 项自动化测试全部通过
- Release 启动冒烟测试通过