### PR TITLE
Improve export queue output path and file name selection

### DIFF
--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -138,6 +138,7 @@
     <x:String x:Key="String.ClearQueue">Clear Queue</x:String>
     <x:String x:Key="String.Clips">Clips</x:String>
     <x:String x:Key="String.QueueRemove">Remove</x:String>
+    <x:String x:Key="String.ExportQueue.DuplicateOutputPath">The output path “{0}” is already present in the export queue. Choose a different file name or folder.</x:String>
     <x:String x:Key="String.Menu.TsCheck">TS Quick _Check...</x:String>
     <x:String x:Key="String.Menu.TsTimelineRepair">TS _Timeline Repair...</x:String>
     <x:String x:Key="String.Menu.TsFilter">TS Stream _Filter</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -138,6 +138,7 @@
     <x:String x:Key="String.ClearQueue">清空队列</x:String>
     <x:String x:Key="String.Clips">片段</x:String>
     <x:String x:Key="String.QueueRemove">移除</x:String>
+    <x:String x:Key="String.ExportQueue.DuplicateOutputPath">输出路径“{0}”已存在于导出队列中，请选择其他文件名或目录。</x:String>
     <x:String x:Key="String.Menu.TsCheck">TS 快速检查(_C)...</x:String>
     <x:String x:Key="String.Menu.TsTimelineRepair">TS 时间轴修复(_T)...</x:String>
     <x:String x:Key="String.Menu.TsFilter">TS 流过滤器(_F)</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -138,6 +138,7 @@
     <x:String x:Key="String.ClearQueue">清空佇列</x:String>
     <x:String x:Key="String.Clips">片段</x:String>
     <x:String x:Key="String.QueueRemove">移除</x:String>
+    <x:String x:Key="String.ExportQueue.DuplicateOutputPath">輸出路徑「{0}」已存在於匯出佇列中，請選擇其他檔名或資料夾。</x:String>
     <x:String x:Key="String.Menu.TsCheck">TS 快速檢查(_C)...</x:String>
     <x:String x:Key="String.Menu.TsTimelineRepair">TS 時間軸修復(_T)...</x:String>
     <x:String x:Key="String.Menu.TsFilter">TS 串流過濾器(_F)</x:String>

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -83,6 +83,7 @@ public partial class MainWindowViewModel : ViewModelBase
     public partial ObservableCollection<PickedClip> Clips { get; set; } = new();
 
     private long _queueIdCounter;
+    private string? _lastQueueOutputDirectory;
     public ObservableCollection<ExportQueueItem> ExportQueue { get; } = new();
 
     public bool HasExportQueue => ExportQueue.Count > 0;
@@ -800,13 +801,29 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]
     private async Task AddToQueueAsync()
     {
-        var defaultName = Path.GetFileNameWithoutExtension(SelectedClip!.InFileInfo.FullName)
-            + $"_({CommonUtil.FormatSeconds(SelectedClip!.StartTime, true)}-{CommonUtil.FormatSeconds(SelectedClip!.EndTime, true)}).ts";
+        var sourceDirectory = Path.GetDirectoryName(SelectedClip!.InFileInfo.FullName)!;
+        var generatedName = GenerateQueueFileName(
+            SelectedClip!.InFileInfo.FullName, SelectedClip!.StartTime, SelectedClip!.EndTime);
+        var previousItem = ExportQueue.LastOrDefault();
+        // 只有上一项确实偏离系统默认名称时，才把它当作用户的手工命名参照；如果用户
+        // 始终沿用默认名称，则每个源文件继续独立生成文件名，仅记住输出目录。
+        var suggestedName = previousItem is not null && !FileNamesEqual(
+            previousItem.OutputFileName,
+            GenerateQueueFileName(
+                previousItem.SourceFilePath,
+                previousItem.StartTimeSeconds,
+                previousItem.EndTimeSeconds))
+            ? previousItem.OutputFileName
+            : generatedName;
+        var suggestedDirectory = !string.IsNullOrWhiteSpace(_lastQueueOutputDirectory) &&
+                                 Directory.Exists(_lastQueueOutputDirectory)
+            ? _lastQueueOutputDirectory
+            : sourceDirectory;
         var settings = new SaveFileDialogSettings
         {
             Title = LocalizationManager.Instance.String_AddToQueue,
-            SuggestedStartLocation = new DesktopDialogStorageFolder(Path.GetDirectoryName(SelectedClip!.InFileInfo.FullName)!),
-            SuggestedFileName = defaultName,
+            SuggestedStartLocation = new DesktopDialogStorageFolder(suggestedDirectory),
+            SuggestedFileName = suggestedName,
             Filters = new List<FileFilter>()
             {
                 new(LocalizationManager.Instance.String_TsFiles, new[] { "ts" }),
@@ -815,13 +832,25 @@ public partial class MainWindowViewModel : ViewModelBase
             DefaultExtension = "ts"
         };
         var result = await _dialogService.ShowSaveFileDialogAsync(this, settings);
-        if (result is null) return;
+        if (result?.Path is null) return;
+
+        var outputPath = result.Path.LocalPath;
+        if (ExportQueue.Any(item => PathsEqual(item.OutputFilePath, outputPath)))
+        {
+            await ShowMessageAsync(
+                string.Format(
+                    LocalizationManager.Instance.String_ExportQueue_DuplicateOutputPath,
+                    outputPath),
+                LocalizationManager.Instance.String_Error,
+                MessageBoxIcon.Error);
+            return;
+        }
 
         var item = new ExportQueueItem
         {
             QueueItemId = Interlocked.Increment(ref _queueIdCounter),
             SourceFilePath = SelectedClip!.InFileInfo.FullName,
-            OutputFilePath = result!.Path!.LocalPath,
+            OutputFilePath = outputPath,
             StartPosition = SelectedClip!.StartPosition,
             EndPosition = SelectedClip!.EndPosition,
             SourceFileName = Path.GetFileName(SelectedClip!.InFileInfo.FullName),
@@ -832,6 +861,7 @@ public partial class MainWindowViewModel : ViewModelBase
                 - SelectedClip!.StartPosition),
         };
         ExportQueue.Add(item);
+        _lastQueueOutputDirectory = Path.GetDirectoryName(outputPath);
         OnPropertyChanged(nameof(HasExportQueue));
         OnPropertyChanged(nameof(ExportQueueCount));
         AddToQueueCommand.NotifyCanExecuteChanged();
@@ -863,6 +893,21 @@ public partial class MainWindowViewModel : ViewModelBase
     }
 
     private bool HasExportQueueItems => ExportQueue.Count > 0;
+
+    private static string GenerateQueueFileName(
+        string sourceFilePath,
+        double startTimeSeconds,
+        double endTimeSeconds) =>
+        Path.GetFileNameWithoutExtension(sourceFilePath) +
+        $"_({CommonUtil.FormatSeconds(startTimeSeconds, true)}-{CommonUtil.FormatSeconds(endTimeSeconds, true)}).ts";
+
+    private static bool FileNamesEqual(string left, string right) => string.Equals(
+        left, right,
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+    private static bool PathsEqual(string left, string right) => string.Equals(
+        Path.GetFullPath(left), Path.GetFullPath(right),
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
 
     [RelayCommand(CanExecute = nameof(HasExportQueueItems))]
     private async Task BatchExportQueueAsync()


### PR DESCRIPTION
## Overview

This update improves the workflow for adding multiple clips to the export queue by reducing repeated directory navigation and making manual file naming easier to follow.

## Key changes

- Remember the most recently used export queue output directory.
- Open subsequent save dialogs in the remembered directory.
- Continue generating an independent default file name for each source when users retain the generated names.
- Prefill the previous queue item’s file name only after a custom name has been used.
- Avoid guessing or automatically incrementing dates, episode numbers, or other naming patterns.
- Detect duplicate full output paths within the queue.
- Show a Classic Avalonia error message when a duplicate path is selected.
- Add localized messages for Simplified Chinese, Traditional Chinese, and English.

## Validation

- Release build completed successfully.
- All 28 automated tests pass.
- Localization resource keys are consistent across all supported languages.

---

## 概述

优化连续向导出队列添加多个片段时的保存路径和文件名体验，减少重复切换目录及手动记忆上一项名称的操作。

## 主要改进

- 记住最近一次成功使用的队列输出目录。
- 后续加入队列时自动从该目录打开保存窗口。
- 如果用户始终保留系统默认文件名，每个源文件继续独立生成默认名称。
- 如果上一项使用了自定义文件名，下一项将预填上一项名称作为手动命名参照。
- 不推测或自动递增日期、集数等命名规则。
- 检测队列内重复的完整输出路径。
- 路径重复时使用 Classic Avalonia 错误提示框阻止加入。
- 补充简体中文、繁体中文和英文提示文本。

## 验证

- Release 构建成功。
- 28 项自动化测试全部通过。
- 三种语言资源键保持一致。