### PR TITLE
Add selected clip merging with continuous TS timestamps

### DIFF
--- a/src/TSCutter.GUI.Tests/TsClipMergeServiceTests.cs
+++ b/src/TSCutter.GUI.Tests/TsClipMergeServiceTests.cs
@@ -1,0 +1,215 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TSCutter.GUI.Models;
+using TSCutter.GUI.Services;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public sealed class TsClipMergeServiceTests
+{
+    private const int PacketSize = TsStreamAnalyzer.PacketSize;
+    private const int MediaPid = 0x0100;
+    private const long TimestampWrap = 1L << 33;
+
+    [Fact]
+    public async Task MergeMakesJoinContinuousAndPreservesInternalTransportDamage()
+    {
+        var sourcePath = Path.Combine(Path.GetTempPath(), $"ts-merge-{Guid.NewGuid():N}.ts");
+        var outputPath = sourcePath + ".merged.ts";
+        try
+        {
+            var packets = Enumerable.Range(0, 30)
+                .Select(index => CreatePacket(index, index * 9_000L))
+                .ToArray();
+            // 第二段内部故意保留一个 CC 跳号和一个 TEI；合并只能修复片段接缝，不能掩盖它们。
+            packets[25][3] = (byte)((packets[25][3] & 0xF0) | 0x0B);
+            packets[26][1] |= 0x80;
+            await File.WriteAllBytesAsync(sourcePath, packets.SelectMany(packet => packet).ToArray());
+
+            var result = await new TsClipMergeService().MergeAsync(new TsClipMergeRequest
+            {
+                SourcePath = sourcePath,
+                OutputPath = outputPath,
+                Ranges =
+                [
+                    new TsClipMergeRange(0, 10 * PacketSize, 0, 1),
+                    new TsClipMergeRange(20 * PacketSize, 30 * PacketSize, 2, 3)
+                ]
+            });
+
+            var output = await File.ReadAllBytesAsync(outputPath);
+            Assert.Equal(20 * PacketSize, output.Length);
+            Assert.Equal(2, result.SegmentCount);
+            Assert.True(result.RewrittenPcrCount > 0);
+            Assert.True(result.RewrittenTimestampCount > 0);
+            Assert.True(result.RewrittenContinuityCount > 0);
+
+            var previous = output.AsSpan(9 * PacketSize, PacketSize);
+            var joined = output.AsSpan(10 * PacketSize, PacketSize);
+            Assert.Equal(9, previous[3] & 0x0F);
+            Assert.Equal(10, joined[3] & 0x0F);
+            Assert.Equal(9_000, ReadPcr(joined) - ReadPcr(previous));
+            Assert.Equal(9_000, ReadPts(joined) - ReadPts(previous));
+
+            var beforeGap = output.AsSpan(14 * PacketSize, PacketSize);
+            var gapPacket = output.AsSpan(15 * PacketSize, PacketSize);
+            Assert.NotEqual(((beforeGap[3] & 0x0F) + 1) & 0x0F, gapPacket[3] & 0x0F);
+            Assert.NotEqual(0, output[16 * PacketSize + 1] & 0x80);
+
+            var verification = await new TsStreamAnalyzer().AnalyzeAsync(
+                outputPath,
+                options: new TsStreamAnalyzeOptions
+                {
+                    Features = TsStreamAnalyzeFeatures.ContinuityValidation |
+                               TsStreamAnalyzeFeatures.DetailedEvents
+                });
+            Assert.Equal(1, verification.Pids[MediaPid].ContinuityErrors);
+            Assert.Equal(1, verification.Pids[MediaPid].TransportErrors);
+            Assert.Contains(verification.Events, item => item.Type == TsCheckEventType.TransportError);
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public async Task CancelledMergeDeletesIncompleteOutput()
+    {
+        var sourcePath = Path.Combine(Path.GetTempPath(), $"ts-merge-{Guid.NewGuid():N}.ts");
+        var outputPath = sourcePath + ".cancelled.ts";
+        try
+        {
+            const int packetCount = 10_000;
+            await File.WriteAllBytesAsync(sourcePath, Enumerable.Range(0, packetCount)
+                .SelectMany(index => CreatePacket(index, index * 900L)).ToArray());
+            using var cancellation = new CancellationTokenSource();
+            var progress = new InlineProgress<TsClipMergeProgress>(_ => cancellation.Cancel());
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(() =>
+                new TsClipMergeService().MergeAsync(new TsClipMergeRequest
+                {
+                    SourcePath = sourcePath,
+                    OutputPath = outputPath,
+                    Ranges = [new TsClipMergeRange(0, packetCount * PacketSize, 0, 100)]
+                }, progress, cancellation.Token));
+            Assert.False(File.Exists(outputPath));
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+            File.Delete(outputPath);
+        }
+    }
+
+    [Fact]
+    public async Task OverlappingSelectionsAreWrittenOnceInTimelineOrder()
+    {
+        var sourcePath = Path.Combine(Path.GetTempPath(), $"ts-merge-{Guid.NewGuid():N}.ts");
+        var outputPath = sourcePath + ".overlap.ts";
+        try
+        {
+            await File.WriteAllBytesAsync(sourcePath, Enumerable.Range(0, 20)
+                .SelectMany(index => CreatePacket(index, index * 9_000L)).ToArray());
+
+            var result = await new TsClipMergeService().MergeAsync(new TsClipMergeRequest
+            {
+                SourcePath = sourcePath,
+                OutputPath = outputPath,
+                Ranges =
+                [
+                    new TsClipMergeRange(5 * PacketSize, 15 * PacketSize, 0.5, 1.5),
+                    new TsClipMergeRange(0, 10 * PacketSize, 0, 1)
+                ]
+            });
+
+            Assert.Equal(1, result.SegmentCount);
+            Assert.Equal(15 * PacketSize, new FileInfo(outputPath).Length);
+        }
+        finally
+        {
+            File.Delete(sourcePath);
+            File.Delete(outputPath);
+        }
+    }
+
+    private static byte[] CreatePacket(int index, long timestamp90k)
+    {
+        var packet = new byte[PacketSize];
+        packet.AsSpan().Fill(0xFF);
+        packet[0] = 0x47;
+        packet[1] = (byte)(0x40 | ((MediaPid >> 8) & 0x1F));
+        packet[2] = (byte)(MediaPid & 0xFF);
+        packet[3] = (byte)(0x30 | (index & 0x0F));
+        packet[4] = 7;
+        packet[5] = 0x10;
+        WritePcr(packet.AsSpan(6, 6), timestamp90k);
+
+        var payload = packet.AsSpan(12);
+        payload[0] = 0;
+        payload[1] = 0;
+        payload[2] = 1;
+        payload[3] = 0xE0;
+        payload[4] = 0;
+        payload[5] = 0;
+        payload[6] = 0x80;
+        payload[7] = 0x80;
+        payload[8] = 5;
+        WriteTimestamp(payload[9..14], timestamp90k);
+        return packet;
+    }
+
+    private static long ReadPcr(ReadOnlySpan<byte> packet) =>
+        ((long)packet[6] << 25) |
+        ((long)packet[7] << 17) |
+        ((long)packet[8] << 9) |
+        ((long)packet[9] << 1) |
+        ((long)packet[10] >> 7);
+
+    private static long ReadPts(ReadOnlySpan<byte> packet)
+    {
+        var value = packet[21..26];
+        return ((long)(value[0] & 0x0E) << 29) |
+               ((long)value[1] << 22) |
+               ((long)(value[2] & 0xFE) << 14) |
+               ((long)value[3] << 7) |
+               ((long)value[4] >> 1);
+    }
+
+    private static void WritePcr(Span<byte> value, long timestamp90k)
+    {
+        var raw = ModuloTimestamp(timestamp90k);
+        value[0] = (byte)(raw >> 25);
+        value[1] = (byte)(raw >> 17);
+        value[2] = (byte)(raw >> 9);
+        value[3] = (byte)(raw >> 1);
+        value[4] = (byte)(((raw & 1) << 7) | 0x7E);
+        value[5] = 0;
+    }
+
+    private static void WriteTimestamp(Span<byte> value, long timestamp90k)
+    {
+        var raw = ModuloTimestamp(timestamp90k);
+        value[0] = (byte)(0x20 | (((raw >> 30) & 7) << 1) | 1);
+        value[1] = (byte)(raw >> 22);
+        value[2] = (byte)((((raw >> 15) & 0x7F) << 1) | 1);
+        value[3] = (byte)(raw >> 7);
+        value[4] = (byte)(((raw & 0x7F) << 1) | 1);
+    }
+
+    private static long ModuloTimestamp(long value)
+    {
+        value %= TimestampWrap;
+        return value < 0 ? value + TimestampWrap : value;
+    }
+
+    private sealed class InlineProgress<T>(Action<T> callback) : IProgress<T>
+    {
+        public void Report(T value) => callback(value);
+    }
+}

--- a/src/TSCutter.GUI.Tests/TsTimestampFieldCodecTests.cs
+++ b/src/TSCutter.GUI.Tests/TsTimestampFieldCodecTests.cs
@@ -1,0 +1,134 @@
+using System;
+using TSCutter.GUI.Utils;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+/// <summary>验证各服务共享的 TS 时间戳字段编解码规则。</summary>
+public sealed class TsTimestampFieldCodecTests
+{
+    private const int PacketSize = TsUtil.TsPacketSize;
+    private const long TimestampWrap = 1L << 33;
+
+    [Fact]
+    public void RewritesPcrPtsAndDtsWithTheSameWrappedCorrection()
+    {
+        var packet = CreateTimestampPacket(1_000, 2_000, 1_500);
+
+        Assert.True(TsTimestampFieldCodec.RewritePcr(packet, -3_000));
+        Assert.Equal(2, TsTimestampFieldCodec.RewritePesTimestamps(packet, -3_000));
+
+        Assert.True(TsTimestampFieldCodec.TryReadPcr(
+            packet, out var pcr, out _, out var discontinuity));
+        Assert.True(discontinuity);
+        Assert.Equal(TimestampWrap - 2_000, pcr);
+        Assert.Equal(TimestampWrap - 1_000, ReadTimestamp(packet.AsSpan(21, 5)));
+        Assert.Equal(TimestampWrap - 1_500, ReadTimestamp(packet.AsSpan(26, 5)));
+        Assert.Equal(0x31, packet[21] & 0xF1);
+        Assert.Equal(0x11, packet[26] & 0xF1);
+    }
+
+    [Fact]
+    public void DoesNotTreatOrdinaryPayloadAsPesTimestampHeader()
+    {
+        var packet = new byte[PacketSize];
+        packet.AsSpan().Fill(0xFF);
+        packet[0] = 0x47;
+        packet[1] = 0x40;
+        packet[3] = 0x10;
+
+        Assert.False(TsTimestampFieldCodec.TryLocatePesTimestamps(
+            packet, out _, out _));
+        Assert.Equal(0, TsTimestampFieldCodec.RewritePesTimestamps(packet, 90_000));
+    }
+
+    [Fact]
+    public void MarkerBitPolicyRemainsExplicitForRepairAndPacketizerCallers()
+    {
+        var repairPacket = CreateTimestampPacket(1_000, 2_000, 1_500);
+        repairPacket[21] &= 0xFE;
+        TsTimestampFieldCodec.RewritePesTimestamps(repairPacket, 9_000);
+        Assert.Equal(0, repairPacket[21] & 0x01);
+
+        var packetizerPacket = CreateTimestampPacket(1_000, 2_000, 1_500);
+        packetizerPacket[21] &= 0xFE;
+        TsTimestampFieldCodec.RewritePesTimestamps(
+            packetizerPacket, 0, preserveFirstMarkerBit: false);
+        Assert.Equal(1, packetizerPacket[21] & 0x01);
+        Assert.Equal(2_000, ReadTimestamp(packetizerPacket.AsSpan(21, 5)));
+    }
+
+    [Fact]
+    public void UnwrapsOnlyAcrossTheHalfCycleBoundary()
+    {
+        var lastRaw = TimestampWrap - 100;
+        var wrapOffset = 0L;
+
+        var unwrapped = TsTimestampFieldCodec.UnwrapTimestamp(
+            50, ref lastRaw, ref wrapOffset);
+
+        Assert.Equal(TimestampWrap + 50, unwrapped);
+        Assert.Equal(50, lastRaw);
+        Assert.Equal(TimestampWrap, wrapOffset);
+    }
+
+    private static byte[] CreateTimestampPacket(long pcr90k, long pts90k, long dts90k)
+    {
+        var packet = new byte[PacketSize];
+        packet.AsSpan().Fill(0xFF);
+        packet[0] = 0x47;
+        packet[1] = 0x40;
+        packet[3] = 0x30;
+        packet[4] = 7;
+        packet[5] = 0x90;
+        WritePcr(packet.AsSpan(6, 6), pcr90k);
+
+        var payload = packet.AsSpan(12);
+        payload[0] = 0;
+        payload[1] = 0;
+        payload[2] = 1;
+        payload[3] = 0xE0;
+        payload[4] = 0;
+        payload[5] = 0;
+        payload[6] = 0x80;
+        payload[7] = 0xC0;
+        payload[8] = 10;
+        WriteTimestamp(payload[9..14], pts90k, 0x30);
+        WriteTimestamp(payload[14..19], dts90k, 0x10);
+        return packet;
+    }
+
+    private static void WritePcr(Span<byte> value, long timestamp90k)
+    {
+        var raw = ModuloTimestamp(timestamp90k);
+        value[0] = (byte)(raw >> 25);
+        value[1] = (byte)(raw >> 17);
+        value[2] = (byte)(raw >> 9);
+        value[3] = (byte)(raw >> 1);
+        value[4] = (byte)(((raw & 1) << 7) | 0x7E);
+        value[5] = 0;
+    }
+
+    private static void WriteTimestamp(Span<byte> value, long timestamp90k, byte prefix)
+    {
+        var raw = ModuloTimestamp(timestamp90k);
+        value[0] = (byte)(prefix | (((raw >> 30) & 7) << 1) | 1);
+        value[1] = (byte)(raw >> 22);
+        value[2] = (byte)((((raw >> 15) & 0x7F) << 1) | 1);
+        value[3] = (byte)(raw >> 7);
+        value[4] = (byte)(((raw & 0x7F) << 1) | 1);
+    }
+
+    private static long ReadTimestamp(ReadOnlySpan<byte> value) =>
+        ((long)(value[0] & 0x0E) << 29) |
+        ((long)value[1] << 22) |
+        ((long)(value[2] & 0xFE) << 14) |
+        ((long)value[3] << 7) |
+        ((long)value[4] >> 1);
+
+    private static long ModuloTimestamp(long value)
+    {
+        value %= TimestampWrap;
+        return value < 0 ? value + TimestampWrap : value;
+    }
+}

--- a/src/TSCutter.GUI/Controls/CustomSlider.cs
+++ b/src/TSCutter.GUI/Controls/CustomSlider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Controls.Primitives;
@@ -8,6 +9,7 @@ using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
+using TSCutter.GUI.Models;
 using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.Controls;
@@ -15,7 +17,7 @@ namespace TSCutter.GUI.Controls;
 public class CustomSlider : Grid
 {
     private readonly Slider _innerSlider;
-    private readonly Border _highlightBorder;
+    private readonly Canvas _highlightCanvas;
     private readonly Border _highlightContainer;
     private Track? _track;
     private Thumb? _thumb;
@@ -36,6 +38,9 @@ public class CustomSlider : Grid
 
     public static readonly StyledProperty<double> RangeEndProperty =
         AvaloniaProperty.Register<CustomSlider, double>(nameof(RangeEnd), -1);
+
+    public static readonly StyledProperty<IReadOnlyList<ClipTimelineRange>?> RangesProperty =
+        AvaloniaProperty.Register<CustomSlider, IReadOnlyList<ClipTimelineRange>?>(nameof(Ranges));
 
     public double Minimum
     {
@@ -67,6 +72,12 @@ public class CustomSlider : Grid
         set => SetValue(RangeEndProperty, value);
     }
 
+    public IReadOnlyList<ClipTimelineRange>? Ranges
+    {
+        get => GetValue(RangesProperty);
+        set => SetValue(RangesProperty, value);
+    }
+
     static CustomSlider()
     {
         MinimumProperty.Changed.AddClassHandler<CustomSlider>((s, e) =>
@@ -90,6 +101,7 @@ public class CustomSlider : Grid
         });
         RangeStartProperty.Changed.AddClassHandler<CustomSlider>((s, _) => s.UpdateHighlightPosition());
         RangeEndProperty.Changed.AddClassHandler<CustomSlider>((s, _) => s.UpdateHighlightPosition());
+        RangesProperty.Changed.AddClassHandler<CustomSlider>((s, _) => s.UpdateHighlightPosition());
     }
 
     public CustomSlider()
@@ -114,9 +126,8 @@ public class CustomSlider : Grid
         _innerSlider.PropertyChanged += InnerSliderPropertyChanged;
         _innerSlider.TemplateApplied += InnerSlider_TemplateApplied;
 
-        _highlightBorder = new Border
+        _highlightCanvas = new Canvas
         {
-            Background = new SolidColorBrush(Colors.Green),
             IsHitTestVisible = false,
             HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Left,
             VerticalAlignment = Avalonia.Layout.VerticalAlignment.Stretch,
@@ -127,7 +138,7 @@ public class CustomSlider : Grid
         {
             IsHitTestVisible = false,
             Height = 5,
-            Child = _highlightBorder,
+            Child = _highlightCanvas,
         };
         Grid.SetRow(_highlightContainer, 1);
 
@@ -221,9 +232,9 @@ public class CustomSlider : Grid
 
     private void UpdateHighlightPosition()
     {
-        if (_track == null || _thumb == null || Maximum <= Minimum || RangeStart < 0 || RangeEnd < 0)
+        if (_track == null || _thumb == null || Maximum <= Minimum)
         {
-            _highlightBorder.Opacity = 0;
+            _highlightCanvas.Opacity = 0;
             return;
         }
 
@@ -234,22 +245,52 @@ public class CustomSlider : Grid
         var thumbWidth = _thumb.Bounds.Width;
         var trackWidth = _track.Bounds.Width;
         var effectiveWidth = trackWidth - thumbWidth;
-        if (effectiveWidth <= 0) return;
+        if (effectiveWidth <= 0)
+        {
+            _highlightCanvas.Opacity = 0;
+            return;
+        }
 
         // 用当前 Thumb 位置和当前 Value 反推 Thumb 在 Value=Min 时的基准中心位置
         var currentRatio = Math.Clamp((Value - Minimum) / (Maximum - Minimum), 0, 1);
         var baseCenterX = thumbCenterCurrent.Value.X - currentRatio * effectiveWidth;
 
-        var range = Maximum - Minimum;
-        var startRatio = Math.Clamp((RangeStart - Minimum) / range, 0, 1);
-        var endRatio = Math.Clamp((RangeEnd - Minimum) / range, 0, 1);
+        _highlightCanvas.Width = Bounds.Width;
+        _highlightCanvas.Children.Clear();
 
-        // 高亮条从 RangeStart 的 Thumb 中心到 RangeEnd 的 Thumb 中心
-        var left = baseCenterX + startRatio * effectiveWidth;
-        var width = Math.Max(0, (endRatio - startRatio) * effectiveWidth);
+        var ranges = Ranges is { Count: > 0 }
+            ? Ranges
+            : RangeStart >= 0 && RangeEnd >= 0
+                ? [new ClipTimelineRange(RangeStart, RangeEnd, true)]
+                : null;
+        if (ranges is null)
+        {
+            _highlightCanvas.Opacity = 0;
+            return;
+        }
 
-        _highlightBorder.Margin = new Thickness(left, 0, 0, 0);
-        _highlightBorder.Width = width;
-        _highlightBorder.Opacity = 1;
+        var valueRange = Maximum - Minimum;
+        // 非活动区间先绘制，活动区间最后绘制，重叠时仍能看出当前编辑对象。
+        foreach (var item in ranges.OrderBy(range => range.IsActive))
+        {
+            if (item.End <= item.Start)
+                continue;
+            var startRatio = Math.Clamp((item.Start - Minimum) / valueRange, 0, 1);
+            var endRatio = Math.Clamp((item.End - Minimum) / valueRange, 0, 1);
+            var left = baseCenterX + startRatio * effectiveWidth;
+            var width = Math.Max(1, (endRatio - startRatio) * effectiveWidth);
+            var highlight = new Border
+            {
+                Width = width,
+                Height = 5,
+                Background = new SolidColorBrush(Colors.Green),
+                Opacity = item.IsActive ? 1 : 0.55,
+                IsHitTestVisible = false
+            };
+            Canvas.SetLeft(highlight, left);
+            Canvas.SetTop(highlight, 0);
+            _highlightCanvas.Children.Add(highlight);
+        }
+        _highlightCanvas.Opacity = _highlightCanvas.Children.Count > 0 ? 1 : 0;
     }
 }

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -130,6 +130,14 @@
     <x:String x:Key="String.CaptureFrame.Format">Format</x:String>
     <x:String x:Key="String.AddToQueue">Add to Queue...</x:String>
     <x:String x:Key="String.AddToQueueTip">Add current clip to export queue</x:String>
+    <x:String x:Key="String.MergeClips.Menu">Merge Selected Clips...</x:String>
+    <x:String x:Key="String.MergeClips.Title">Merge Selected Clips</x:String>
+    <x:String x:Key="String.MergeClips.Completed">Merge completed.&#10;&#10;Output: {0}</x:String>
+    <x:String x:Key="String.MergeClips.OutputMatchesSource">The output file cannot overwrite the source file.</x:String>
+    <x:String x:Key="String.MergeClips.NoSync">No valid 188-byte TS packet structure was found.</x:String>
+    <x:String x:Key="String.MergeClips.InvalidRange">The selected clip ranges are invalid or contain no output data.</x:String>
+    <x:String x:Key="String.MergeClips.SourceChanged">The source file changed during processing or could not be read.</x:String>
+    <x:String x:Key="String.Clips.SelectionSummary">{0} clips / {1}</x:String>
     <x:String x:Key="String.BatchExportQueue">Batch Export</x:String>
     <x:String x:Key="String.BatchExportQueueTip">Export all clips in the queue</x:String>
     <x:String x:Key="String.BatchExportConfirm">Export {0} clips from the queue?&#10;&#10;Continue?</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -130,6 +130,14 @@
     <x:String x:Key="String.CaptureFrame.Format">格式</x:String>
     <x:String x:Key="String.AddToQueue">加入队列...</x:String>
     <x:String x:Key="String.AddToQueueTip">将当前片段加入导出队列</x:String>
+    <x:String x:Key="String.MergeClips.Menu">合并选中剪辑...</x:String>
+    <x:String x:Key="String.MergeClips.Title">合并选中剪辑</x:String>
+    <x:String x:Key="String.MergeClips.Completed">合并完成！&#10;&#10;输出文件：{0}</x:String>
+    <x:String x:Key="String.MergeClips.OutputMatchesSource">输出文件不能覆盖源文件。</x:String>
+    <x:String x:Key="String.MergeClips.NoSync">没有找到有效的 188 字节 TS 包结构。</x:String>
+    <x:String x:Key="String.MergeClips.InvalidRange">选中的剪辑范围无效或没有可输出的数据。</x:String>
+    <x:String x:Key="String.MergeClips.SourceChanged">源文件在处理期间发生变化或无法继续读取。</x:String>
+    <x:String x:Key="String.Clips.SelectionSummary">{0} 个剪辑 / {1}</x:String>
     <x:String x:Key="String.BatchExportQueue">批量导出</x:String>
     <x:String x:Key="String.BatchExportQueueTip">导出队列中的所有片段</x:String>
     <x:String x:Key="String.BatchExportConfirm">将导出队列中的 {0} 个片段，确认继续？</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -130,6 +130,14 @@
     <x:String x:Key="String.CaptureFrame.Format">格式</x:String>
     <x:String x:Key="String.AddToQueue">加入佇列...</x:String>
     <x:String x:Key="String.AddToQueueTip">將目前片段加入匯出佇列</x:String>
+    <x:String x:Key="String.MergeClips.Menu">合併選取的剪輯...</x:String>
+    <x:String x:Key="String.MergeClips.Title">合併選取的剪輯</x:String>
+    <x:String x:Key="String.MergeClips.Completed">合併完成！&#10;&#10;輸出檔案：{0}</x:String>
+    <x:String x:Key="String.MergeClips.OutputMatchesSource">輸出檔案不能覆蓋來源檔案。</x:String>
+    <x:String x:Key="String.MergeClips.NoSync">沒有找到有效的 188 位元組 TS 封包結構。</x:String>
+    <x:String x:Key="String.MergeClips.InvalidRange">選取的剪輯範圍無效或沒有可輸出的資料。</x:String>
+    <x:String x:Key="String.MergeClips.SourceChanged">來源檔案在處理期間發生變更或無法繼續讀取。</x:String>
+    <x:String x:Key="String.Clips.SelectionSummary">{0} 個剪輯 / {1}</x:String>
     <x:String x:Key="String.BatchExportQueue">批次匯出</x:String>
     <x:String x:Key="String.BatchExportQueueTip">匯出佇列中的所有片段</x:String>
     <x:String x:Key="String.BatchExportConfirm">將匯出佇列中的 {0} 個片段匯出，確認繼續？</x:String>

--- a/src/TSCutter.GUI/Models/ClipTimelineRange.cs
+++ b/src/TSCutter.GUI/Models/ClipTimelineRange.cs
@@ -1,0 +1,6 @@
+namespace TSCutter.GUI.Models;
+
+/// <summary>
+/// 主时间轴上的轻量剪辑区间；活动项用于保持当前编辑区间的强调显示。
+/// </summary>
+public readonly record struct ClipTimelineRange(double Start, double End, bool IsActive);

--- a/src/TSCutter.GUI/Models/PickedClip.cs
+++ b/src/TSCutter.GUI/Models/PickedClip.cs
@@ -54,6 +54,9 @@ public partial class PickedClip : ObservableObject
     [ObservableProperty]
     private bool _isSelected;
 
+    [ObservableProperty]
+    private bool _isActive;
+
     public required FileInfo InFileInfo { get; init; }
 
     public string StartTimeStr => CommonUtil.FormatSeconds(StartTime);

--- a/src/TSCutter.GUI/Models/TsClipMergeModels.cs
+++ b/src/TSCutter.GUI/Models/TsClipMergeModels.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+
+namespace TSCutter.GUI.Models;
+
+internal readonly record struct TsClipMergeRange(
+    long StartPosition,
+    long EndPosition,
+    double StartTimeSeconds,
+    double EndTimeSeconds);
+
+internal sealed class TsClipMergeRequest
+{
+    public required string SourcePath { get; init; }
+    public required string OutputPath { get; init; }
+    public required IReadOnlyList<TsClipMergeRange> Ranges { get; init; }
+}
+
+internal readonly record struct TsClipMergeProgress(
+    long BytesProcessed,
+    long TotalBytes,
+    double BytesPerSecond,
+    TimeSpan Elapsed)
+{
+    public double Percent => TotalBytes > 0 ? BytesProcessed * 100.0 / TotalBytes : 0;
+}
+
+internal sealed class TsClipMergeResult
+{
+    public required string OutputPath { get; init; }
+    public required long OutputBytes { get; init; }
+    public required int SegmentCount { get; init; }
+    public required long RewrittenPcrCount { get; init; }
+    public required long RewrittenTimestampCount { get; init; }
+    public required long RewrittenContinuityCount { get; init; }
+    public required TimeSpan Elapsed { get; init; }
+}
+
+internal enum TsClipMergeErrorCode
+{
+    OutputMatchesSource,
+    SourceChanged,
+    NoSync,
+    InvalidRange
+}
+
+internal sealed class TsClipMergeException(
+    TsClipMergeErrorCode code,
+    params object[] arguments) : Exception
+{
+    public TsClipMergeErrorCode Code { get; } = code;
+    public object[] Arguments { get; } = arguments;
+}

--- a/src/TSCutter.GUI/Services/TsClipMergeService.cs
+++ b/src/TSCutter.GUI/Services/TsClipMergeService.cs
@@ -1,0 +1,324 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using TSCutter.GUI.Models;
+using TSCutter.GUI.Utils;
+
+namespace TSCutter.GUI.Services;
+
+/// <summary>
+/// 将同一 TS 文件中的多个剪辑区间合并为单个文件，并在接缝处连续化时间戳和 CC。
+/// </summary>
+internal sealed class TsClipMergeService
+{
+    private const int PacketSize = TsStreamAnalyzer.PacketSize;
+    private const int ReadPacketCount = 4096;
+    private const int SyncProbeBytes = 1024 * 1024;
+    private const int RequiredSyncPackets = 5;
+
+    public async Task<TsClipMergeResult> MergeAsync(
+        TsClipMergeRequest request,
+        IProgress<TsClipMergeProgress>? progress = null,
+        CancellationToken cancellationToken = default)
+    {
+        var sourcePath = Path.GetFullPath(request.SourcePath);
+        var outputPath = Path.GetFullPath(request.OutputPath);
+        if (PathsEqual(sourcePath, outputPath))
+            throw new TsClipMergeException(TsClipMergeErrorCode.OutputMatchesSource);
+
+        var sourceInfo = new FileInfo(sourcePath);
+        if (!sourceInfo.Exists)
+            throw new TsClipMergeException(TsClipMergeErrorCode.SourceChanged);
+
+        var stopwatch = Stopwatch.StartNew();
+        await using var source = new FileStream(
+            sourcePath, FileMode.Open, FileAccess.Read, FileShare.Read,
+            PacketSize * ReadPacketCount, FileOptions.Asynchronous | FileOptions.SequentialScan);
+        var sourceLength = source.Length;
+        var syncOffset = await FindSyncOffsetAsync(source, cancellationToken).ConfigureAwait(false);
+        if (syncOffset < 0)
+            throw new TsClipMergeException(TsClipMergeErrorCode.NoSync);
+
+        var ranges = NormalizeRanges(request.Ranges, syncOffset, sourceLength);
+        if (ranges.Count == 0)
+            throw new TsClipMergeException(TsClipMergeErrorCode.InvalidRange);
+
+        var totalBytes = ranges.Sum(item => item.EndPosition - item.StartPosition);
+        var buffer = ArrayPool<byte>.Shared.Rent(PacketSize * ReadPacketCount);
+        var lastPayloadContinuity = new int[8192];
+        Array.Fill(lastPayloadContinuity, -1);
+        long processedBytes = 0;
+        long rewrittenPcrCount = 0;
+        long rewrittenTimestampCount = 0;
+        long rewrittenContinuityCount = 0;
+
+        try
+        {
+            await using var output = new FileStream(
+                outputPath, FileMode.Create, FileAccess.Write, FileShare.None,
+                buffer.Length, FileOptions.Asynchronous | FileOptions.SequentialScan);
+
+            for (var rangeIndex = 0; rangeIndex < ranges.Count; rangeIndex++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var range = ranges[rangeIndex];
+                var segmentContinuityOffsets = new int[8192];
+                Array.Fill(segmentContinuityOffsets, int.MinValue);
+                source.Position = range.StartPosition;
+                var remaining = range.EndPosition - range.StartPosition;
+
+                while (remaining > 0)
+                {
+                    cancellationToken.ThrowIfCancellationRequested();
+                    var requested = (int)Math.Min(buffer.Length, remaining);
+                    requested -= requested % PacketSize;
+                    if (requested <= 0)
+                        throw new TsClipMergeException(TsClipMergeErrorCode.InvalidRange);
+
+                    await source.ReadExactlyAsync(buffer.AsMemory(0, requested), cancellationToken)
+                        .ConfigureAwait(false);
+                    var packets = buffer.AsSpan(0, requested);
+                    for (var offset = 0; offset < packets.Length; offset += PacketSize)
+                    {
+                        var packet = packets.Slice(offset, PacketSize);
+                        if (packet[0] != 0x47)
+                            throw new TsClipMergeException(
+                                TsClipMergeErrorCode.SourceChanged,
+                                range.StartPosition + (range.EndPosition - range.StartPosition - remaining) + offset);
+
+                        var transportError = (packet[1] & 0x80) != 0;
+                        if (!transportError && range.TimestampCorrection90k != 0)
+                        {
+                            if (TsTimestampFieldCodec.RewritePcr(
+                                    packet, range.TimestampCorrection90k))
+                                rewrittenPcrCount++;
+                            rewrittenTimestampCount += TsTimestampFieldCodec.RewritePesTimestamps(
+                                packet, range.TimestampCorrection90k);
+                        }
+
+                        // 每个后续片段对各 PID 只计算一次固定 CC 偏移。这样既能消除人为
+                        // 剪切产生的接缝跳号，又会完整保留片段内部原有的跳号、重复包和 TEI。
+                        rewrittenContinuityCount += RewriteContinuity(
+                            packet, rangeIndex, segmentContinuityOffsets, lastPayloadContinuity);
+                    }
+
+                    await output.WriteAsync(buffer.AsMemory(0, requested), cancellationToken)
+                        .ConfigureAwait(false);
+                    remaining -= requested;
+                    processedBytes += requested;
+                    progress?.Report(new TsClipMergeProgress(
+                        processedBytes,
+                        totalBytes,
+                        processedBytes / Math.Max(0.001, stopwatch.Elapsed.TotalSeconds),
+                        stopwatch.Elapsed));
+                }
+            }
+
+            await output.FlushAsync(cancellationToken).ConfigureAwait(false);
+            if (source.Length != sourceLength)
+                throw new TsClipMergeException(TsClipMergeErrorCode.SourceChanged);
+
+            progress?.Report(new TsClipMergeProgress(
+                totalBytes,
+                totalBytes,
+                totalBytes / Math.Max(0.001, stopwatch.Elapsed.TotalSeconds),
+                stopwatch.Elapsed));
+            return new TsClipMergeResult
+            {
+                OutputPath = outputPath,
+                OutputBytes = totalBytes,
+                SegmentCount = ranges.Count,
+                RewrittenPcrCount = rewrittenPcrCount,
+                RewrittenTimestampCount = rewrittenTimestampCount,
+                RewrittenContinuityCount = rewrittenContinuityCount,
+                Elapsed = stopwatch.Elapsed
+            };
+        }
+        catch (EndOfStreamException)
+        {
+            TryDelete(outputPath);
+            throw new TsClipMergeException(TsClipMergeErrorCode.SourceChanged);
+        }
+        catch
+        {
+            TryDelete(outputPath);
+            throw;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static List<NormalizedRange> NormalizeRanges(
+        IReadOnlyList<TsClipMergeRange> source,
+        long syncOffset,
+        long fileLength)
+    {
+        var aligned = new List<NormalizedRange>(source.Count);
+        foreach (var item in source)
+        {
+            var rawEnd = item.EndPosition > 0 ? Math.Min(item.EndPosition, fileLength) : fileLength;
+            var rawStart = Math.Clamp(item.StartPosition, syncOffset, fileLength);
+            var start = AlignDown(rawStart, syncOffset);
+            var end = AlignDown(rawEnd, syncOffset);
+            if (end <= start || item.EndTimeSeconds <= item.StartTimeSeconds)
+                continue;
+            aligned.Add(new NormalizedRange(
+                start, end, item.StartTimeSeconds, item.EndTimeSeconds, 0));
+        }
+
+        aligned.Sort(static (left, right) => left.StartPosition.CompareTo(right.StartPosition));
+        var merged = new List<NormalizedRange>(aligned.Count);
+        foreach (var item in aligned)
+        {
+            if (merged.Count == 0 || item.StartPosition > merged[^1].EndPosition)
+            {
+                merged.Add(item);
+                continue;
+            }
+
+            var previous = merged[^1];
+            merged[^1] = previous with
+            {
+                EndPosition = Math.Max(previous.EndPosition, item.EndPosition),
+                EndTimeSeconds = Math.Max(previous.EndTimeSeconds, item.EndTimeSeconds)
+            };
+        }
+
+        if (merged.Count == 0)
+            return merged;
+
+        var outputStartTime = merged[0].StartTimeSeconds;
+        var accumulatedDuration = 0.0;
+        for (var index = 0; index < merged.Count; index++)
+        {
+            var item = merged[index];
+            var expectedStart = outputStartTime + accumulatedDuration;
+            merged[index] = item with
+            {
+                TimestampCorrection90k = (long)Math.Round(
+                    (expectedStart - item.StartTimeSeconds) * 90_000.0)
+            };
+            accumulatedDuration += item.EndTimeSeconds - item.StartTimeSeconds;
+        }
+        return merged;
+    }
+
+    private static long AlignDown(long value, long syncOffset)
+    {
+        if (value <= syncOffset)
+            return syncOffset;
+        return syncOffset + (value - syncOffset) / PacketSize * PacketSize;
+    }
+
+    private static async Task<long> FindSyncOffsetAsync(
+        FileStream source,
+        CancellationToken cancellationToken)
+    {
+        var requested = (int)Math.Min(
+            source.Length,
+            SyncProbeBytes + RequiredSyncPackets * PacketSize);
+        if (requested < RequiredSyncPackets * PacketSize)
+            return -1;
+
+        var buffer = ArrayPool<byte>.Shared.Rent(requested);
+        try
+        {
+            source.Position = 0;
+            await source.ReadExactlyAsync(buffer.AsMemory(0, requested), cancellationToken)
+                .ConfigureAwait(false);
+            var data = buffer.AsSpan(0, requested);
+            for (var offset = 0; offset + RequiredSyncPackets * PacketSize <= data.Length; offset++)
+            {
+                if (data[offset] != 0x47)
+                    continue;
+                var valid = true;
+                for (var packet = 1; packet < RequiredSyncPackets; packet++)
+                {
+                    if (data[offset + packet * PacketSize] == 0x47)
+                        continue;
+                    valid = false;
+                    break;
+                }
+                if (valid)
+                    return offset;
+            }
+            return -1;
+        }
+        finally
+        {
+            ArrayPool<byte>.Shared.Return(buffer);
+        }
+    }
+
+    private static int RewriteContinuity(
+        Span<byte> packet,
+        int rangeIndex,
+        int[] segmentOffsets,
+        int[] lastPayloadContinuity)
+    {
+        var pid = ((packet[1] & 0x1F) << 8) | packet[2];
+        var adaptationControl = (packet[3] >> 4) & 0x03;
+        var hasPayload = (adaptationControl & 0x01) != 0;
+        if (pid == 0x1FFF || adaptationControl == 0)
+            return 0;
+
+        var original = packet[3] & 0x0F;
+        var changed = 0;
+        if (rangeIndex > 0)
+        {
+            var offset = segmentOffsets[pid];
+            if (offset == int.MinValue && hasPayload)
+            {
+                offset = lastPayloadContinuity[pid] < 0
+                    ? 0
+                    : (lastPayloadContinuity[pid] + 1 - original + 16) & 0x0F;
+                segmentOffsets[pid] = offset;
+            }
+            if (offset != int.MinValue)
+            {
+                var rewritten = (original + offset) & 0x0F;
+                if (rewritten != original)
+                {
+                    packet[3] = (byte)((packet[3] & 0xF0) | rewritten);
+                    changed = 1;
+                }
+            }
+        }
+
+        if (hasPayload)
+            lastPayloadContinuity[pid] = packet[3] & 0x0F;
+        return changed;
+    }
+
+    private static bool PathsEqual(string left, string right) => string.Equals(
+        left,
+        right,
+        OperatingSystem.IsWindows() ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal);
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+        catch
+        {
+            // 清理失败不能覆盖真正的合并或取消异常。
+        }
+    }
+
+    private readonly record struct NormalizedRange(
+        long StartPosition,
+        long EndPosition,
+        double StartTimeSeconds,
+        double EndTimeSeconds,
+        long TimestampCorrection90k);
+}

--- a/src/TSCutter.GUI/Services/TsMultiSourceRepairService.cs
+++ b/src/TSCutter.GUI/Services/TsMultiSourceRepairService.cs
@@ -10,13 +10,13 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 using TSCutter.GUI.Models;
+using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.Services;
 
 public sealed class TsMultiSourceRepairService
 {
     private const int PacketSize = TsStreamAnalyzer.PacketSize;
-    private const long TimestampWrap = 1L << 33;
     private const int ReadBufferSize = PacketSize * 32_768;
     private const int ParallelReadBufferSize = PacketSize * 8_192;
     private const int AnchorLength = 4;
@@ -1733,7 +1733,7 @@ public sealed class TsMultiSourceRepairService
                     if (startsNewPes && TryReadPesStart(packet, info, out _, out var rawPts90k) &&
                         rawPts90k != long.MinValue)
                     {
-                        currentPesPts90k = UnwrapTimestamp(
+                        currentPesPts90k = TsTimestampFieldCodec.UnwrapTimestamp(
                             rawPts90k, ref lastRawPts90k, ref ptsWrapOffset90k);
                         currentPesPts90k = job.TimelineNormalizer?.Normalize(
                             currentPesPts90k, position + offset) ?? currentPesPts90k;
@@ -1925,28 +1925,8 @@ public sealed class TsMultiSourceRepairService
         // PTS 和 ES 指纹，才能在不解码的情况下建立同源视频区间映射。
         expectedTotalLength = declaredLength == 0 ? 0 : declaredLength + 6;
         if ((payload[7] & 0x80) != 0 && payload.Length >= 14)
-            pts90k = ReadPesTimestamp(payload[9..14]);
+            pts90k = TsTimestampFieldCodec.ReadPesTimestamp(payload[9..14]);
         return true;
-    }
-
-    private static long ReadPesTimestamp(ReadOnlySpan<byte> value) =>
-        ((long)(value[0] & 0x0E) << 29) |
-        ((long)value[1] << 22) |
-        ((long)(value[2] & 0xFE) << 14) |
-        ((long)value[3] << 7) |
-        ((long)value[4] >> 1);
-
-    private static long UnwrapTimestamp(long rawTimestamp, ref long lastRawTimestamp, ref long wrapOffset)
-    {
-        if (lastRawTimestamp != long.MinValue)
-        {
-            if (lastRawTimestamp - rawTimestamp > TimestampWrap / 2)
-                wrapOffset += TimestampWrap;
-            else if (rawTimestamp - lastRawTimestamp > TimestampWrap / 2)
-                wrapOffset -= TimestampWrap;
-        }
-        lastRawTimestamp = rawTimestamp;
-        return rawTimestamp + wrapOffset;
     }
 
     private static TsRepairPesSignature CreatePesSignature(ulong hash, int elementaryLength) =>
@@ -2150,35 +2130,20 @@ public sealed class TsMultiSourceRepairService
             if (adaptationLength < 7 || packet.Length < 12 || (packet[5] & 0x10) == 0)
                 return;
 
-            var raw = ((long)packet[6] << 25) |
-                      ((long)packet[7] << 17) |
-                      ((long)packet[8] << 9) |
-                      ((long)packet[9] << 1) |
-                      ((long)packet[10] >> 7);
+            var raw = TsTimestampFieldCodec.ReadPcrBase(packet[6..11]);
             if (!_states.TryGetValue(info.Pid, out var state))
             {
                 state = new PcrState();
                 _states[info.Pid] = state;
                 Samples[info.Pid] = [];
             }
-            var unwrapped = UnwrapPcr(raw, state.LastRaw, state.WrapOffset);
+            var unwrapped = TsTimestampFieldCodec.UnwrapTimestamp(
+                raw, state.LastRaw, state.WrapOffset);
             state.LastRaw = raw;
             state.WrapOffset = unwrapped - raw;
             var packetIndex = Math.Max(0, (fileOffset - syncOffset) / PacketSize);
             Samples[info.Pid].Add(new TsTimelineRepairService.PcrSample(
                 packetIndex, unwrapped, info.Discontinuity));
-        }
-
-        private static long UnwrapPcr(long raw, long lastRaw, long wrapOffset)
-        {
-            if (lastRaw != long.MinValue)
-            {
-                if (lastRaw - raw > TimestampWrap / 2)
-                    wrapOffset += TimestampWrap;
-                else if (raw - lastRaw > TimestampWrap / 2)
-                    wrapOffset -= TimestampWrap;
-            }
-            return raw + wrapOffset;
         }
 
         private sealed class PcrState
@@ -2514,7 +2479,8 @@ public sealed class TsMultiSourceRepairService
                 FinishPes(fileOffset);
                 if (!TryReadPesStart(packet, info, out var expectedLength, out var rawPts90k))
                     return;
-                var pts90k = UnwrapTimestamp(rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
+                var pts90k = TsTimestampFieldCodec.UnwrapTimestamp(
+                    rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
                 pts90k = _timelineNormalizer?.Normalize(pts90k, fileOffset) ?? pts90k;
                 _lastKnownPts90k = pts90k;
                 _lastKnownPtsFileOffset = fileOffset;
@@ -3074,7 +3040,8 @@ public sealed class TsMultiSourceRepairService
                 FinishPes(fileOffset, sourcePath);
                 if (!TryReadPesStart(packet, info, out var expectedLength, out var rawPts90k))
                     return;
-                var pts90k = UnwrapTimestamp(rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
+                var pts90k = TsTimestampFieldCodec.UnwrapTimestamp(
+                    rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
                 pts90k = _timelineNormalizer?.Normalize(pts90k, fileOffset) ?? pts90k;
                 if (pts90k != long.MinValue &&
                     (_lastIndexedPts90k == long.MinValue ||
@@ -3272,7 +3239,8 @@ public sealed class TsMultiSourceRepairService
                 FinishPes(fileOffset);
                 if (!TryReadPesStart(packet, info, out var expectedLength, out var rawPts90k))
                     return;
-                var pts90k = UnwrapTimestamp(rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
+                var pts90k = TsTimestampFieldCodec.UnwrapTimestamp(
+                    rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
                 pts90k = timelineNormalizer?.Normalize(pts90k, fileOffset) ?? pts90k;
                 _activePes = new DonorPesInfo(fileOffset, expectedLength, pts90k);
             }
@@ -3514,7 +3482,8 @@ public sealed class TsMultiSourceRepairService
             if (info.PayloadStart &&
                 TryReadPesStart(packet, info, out _, out var rawPts90k))
             {
-                var value = UnwrapTimestamp(rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
+                var value = TsTimestampFieldCodec.UnwrapTimestamp(
+                    rawPts90k, ref _lastRawPts90k, ref _ptsWrapOffset90k);
                 pts90k = timelineNormalizer?.Normalize(value, fileOffset) ?? value;
                 _activeInspectionPes = new InspectionPes(fileOffset, pts90k.Value);
             }

--- a/src/TSCutter.GUI/Services/TsStreamAnalyzer.cs
+++ b/src/TSCutter.GUI/Services/TsStreamAnalyzer.cs
@@ -9,6 +9,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using TSCutter.GUI.Models;
+using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.Services;
 
@@ -18,7 +19,6 @@ public sealed class TsStreamAnalyzer
     private const int ReadBufferSize = PacketSize * 32_768;
     private const int MaxStoredEvents = 20_000;
     private const int MaxMpegAudioProbeBytes = 64 * 1024;
-    private const long TimestampWrap = 1L << 33;
     private const double PcrGapThresholdSeconds = 0.5;
     private const double TimestampJumpThresholdSeconds = 10;
     private const long TimelineRepairBoundary90k = 22_500;
@@ -460,12 +460,9 @@ public sealed class TsStreamAnalyzer
     private void ProcessPcr(int pid, ReadOnlySpan<byte> bytes, PidState state, long fileOffset, bool discontinuity)
     {
         // PCR base 与 PTS/DTS 同为 90 kHz，先展开 33 位回绕，再检查倒退、跳变和长间隔。
-        var raw = ((long)bytes[0] << 25) |
-                  ((long)bytes[1] << 17) |
-                  ((long)bytes[2] << 9) |
-                  ((long)bytes[3] << 1) |
-                  ((long)bytes[4] >> 7);
-        var pcr = Unwrap(raw, state.LastRawPcr, state.PcrWrapOffset);
+        var raw = TsTimestampFieldCodec.ReadPcrBase(bytes);
+        var pcr = TsTimestampFieldCodec.UnwrapTimestamp(
+            raw, state.LastRawPcr, state.PcrWrapOffset);
         state.LastRawPcr = raw;
         state.PcrWrapOffset = pcr - raw;
 
@@ -1068,13 +1065,14 @@ public sealed class TsStreamAnalyzer
         long? rawPts = null;
         long? rawDts = null;
         if ((flags & 0x02) != 0 && payload.Length >= 14)
-            rawPts = ReadTimestamp(payload[9..14]);
+            rawPts = TsTimestampFieldCodec.ReadPesTimestamp(payload[9..14]);
         if (flags == 0x03 && payload.Length >= 19)
-            rawDts = ReadTimestamp(payload[14..19]);
+            rawDts = TsTimestampFieldCodec.ReadPesTimestamp(payload[14..19]);
 
         if (rawPts is not null)
         {
-            var pts = Unwrap(rawPts.Value, state.LastRawPts, state.PtsWrapOffset);
+            var pts = TsTimestampFieldCodec.UnwrapTimestamp(
+                rawPts.Value, state.LastRawPts, state.PtsWrapOffset);
             state.LastRawPts = rawPts.Value;
             state.PtsWrapOffset = pts - rawPts.Value;
             if (HasFeature(TsStreamAnalyzeFeatures.TimestampValidation))
@@ -1090,7 +1088,8 @@ public sealed class TsStreamAnalyzer
 
         if (rawDts is not null)
         {
-            var dts = Unwrap(rawDts.Value, state.LastRawDts, state.DtsWrapOffset);
+            var dts = TsTimestampFieldCodec.UnwrapTimestamp(
+                rawDts.Value, state.LastRawDts, state.DtsWrapOffset);
             state.LastRawDts = rawDts.Value;
             state.DtsWrapOffset = dts - rawDts.Value;
             if (HasFeature(TsStreamAnalyzeFeatures.TimestampValidation) &&
@@ -1788,25 +1787,6 @@ public sealed class TsStreamAnalyzer
     {
         if (_timelineOrigin90k == long.MinValue)
             _timelineOrigin90k = value;
-    }
-
-    private static long ReadTimestamp(ReadOnlySpan<byte> value) =>
-        ((long)(value[0] & 0x0E) << 29) |
-        ((long)value[1] << 22) |
-        ((long)(value[2] & 0xFE) << 14) |
-        ((long)value[3] << 7) |
-        ((long)value[4] >> 1);
-
-    private static long Unwrap(long raw, long lastRaw, long wrapOffset)
-    {
-        // 跨越半个 33 位周期才视为回绕，避免把普通时间戳倒退错误吞掉。
-        if (lastRaw == long.MinValue)
-            return raw;
-        if (lastRaw - raw > TimestampWrap / 2)
-            wrapOffset += TimestampWrap;
-        else if (raw - lastRaw > TimestampWrap / 2)
-            wrapOffset -= TimestampWrap;
-        return raw + wrapOffset;
     }
 
     private static bool HasValidPsiCrc(ReadOnlySpan<byte> section)

--- a/src/TSCutter.GUI/Services/TsStreamFilterService.cs
+++ b/src/TSCutter.GUI/Services/TsStreamFilterService.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using TSCutter.GUI.Models;
+using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.Services;
 
@@ -249,7 +250,9 @@ public sealed class TsStreamFilterService
                                     elementaryPayload, segment, segmentPayloadOffset,
                                     packet.Slice(targetPayloadOffset, copyLength));
                                 if (payloadStart)
-                                    RewritePesTimestamps(packet, insertion.TimestampOffset90k);
+                                    TsTimestampFieldCodec.RewritePesTimestamps(
+                                        packet, insertion.TimestampOffset90k,
+                                        preserveFirstMarkerBit: false);
                                 segmentPayloadOffset += copyLength;
                                 synthesizedContinuityCounter =
                                     (synthesizedContinuityCounter + 1) & 0x0F;
@@ -283,15 +286,19 @@ public sealed class TsStreamFilterService
                         await EnsurePacketSpaceAsync().ConfigureAwait(false);
                         var packet = outputBuffer.AsSpan(outputLength, PacketSize);
                         repairPacket.CopyTo(packet);
-                        // 只改写 TS 头中的 PID 与 CC；负载、PUSI、adaptation field 和时间戳保持来源原值。
+                        // PID 与 CC 按目标流重写；负载、PUSI 和 adaptation field 保持来源原值，
+                        // PCR、PTS/DTS 仅应用匹配阶段已经确认的固定时间偏移。
                         packet[1] = (byte)((packet[1] & 0x60) | ((insertion.TargetPid >> 8) & 0x1F));
                         packet[2] = (byte)insertion.TargetPid;
                         packet[3] = (byte)((packet[3] & 0xF0) | continuityCounter);
                         if (((packet[3] >> 4) & 0x01) != 0)
                             continuityCounter = (continuityCounter + 1) & 0x0F;
                         if ((packet[1] & 0x40) != 0)
-                            RewritePesTimestamps(packet, insertion.TimestampOffset90k);
-                        RewritePcrTimestamp(packet, insertion.PcrTimestampOffset90k);
+                            TsTimestampFieldCodec.RewritePesTimestamps(
+                                packet, insertion.TimestampOffset90k,
+                                preserveFirstMarkerBit: false);
+                        TsTimestampFieldCodec.RewritePcr(
+                            packet, insertion.PcrTimestampOffset90k);
                         CompletePacket(referenceFileOffset, true, false);
                     }
                 }
@@ -368,8 +375,11 @@ public sealed class TsStreamFilterService
                             payloadPacketCounts[track.TargetPid]++;
                         }
                         if ((packet[1] & 0x40) != 0)
-                            RewritePesTimestamps(packet, track.TimestampOffset90k);
-                        RewritePcrTimestamp(packet, track.PcrTimestampOffset90k);
+                            TsTimestampFieldCodec.RewritePesTimestamps(
+                                packet, track.TimestampOffset90k,
+                                preserveFirstMarkerBit: false);
+                        TsTimestampFieldCodec.RewritePcr(
+                            packet, track.PcrTimestampOffset90k);
                         packetCounts[track.TargetPid]++;
                         CompletePacket(referenceFileOffset, true, false);
                     }
@@ -433,8 +443,11 @@ public sealed class TsStreamFilterService
                     packet[1] = (byte)((packet[1] & 0x60) | ((replacement.TargetPid >> 8) & 0x1F));
                     packet[2] = (byte)replacement.TargetPid;
                     if ((packet[1] & 0x40) != 0)
-                        RewritePesTimestamps(packet, replacement.TimestampOffset90k);
-                    RewritePcrTimestamp(packet, replacement.PcrTimestampOffset90k);
+                        TsTimestampFieldCodec.RewritePesTimestamps(
+                            packet, replacement.TimestampOffset90k,
+                            preserveFirstMarkerBit: false);
+                    TsTimestampFieldCodec.RewritePcr(
+                        packet, replacement.PcrTimestampOffset90k);
                     copiedPackets++;
                 }
                 if (copiedPackets != replacement.PacketCount)
@@ -902,68 +915,6 @@ public sealed class TsStreamFilterService
         var tolerance = ReadBufferSize * 4L;
         return index < boundaries.Length && boundaries[index] - fileOffset <= tolerance ||
                index > 0 && fileOffset - boundaries[index - 1] <= tolerance;
-    }
-
-    private static void RewritePesTimestamps(Span<byte> packet, long offset90k)
-    {
-        var adaptationControl = (packet[3] >> 4) & 0x03;
-        if ((adaptationControl & 0x01) == 0)
-            return;
-        var payloadOffset = 4;
-        if ((adaptationControl & 0x02) != 0)
-            payloadOffset += packet[4] + 1;
-        if (payloadOffset + 14 > PacketSize)
-            return;
-        var payload = packet[payloadOffset..];
-        if (payload[0] != 0 || payload[1] != 0 || payload[2] != 1 || payload.Length < 9)
-            return;
-        var flags = (payload[7] >> 6) & 0x03;
-        if ((flags & 0x02) != 0 && payload.Length >= 14)
-            WritePesTimestamp(payload[9..14], ReadPesTimestamp(payload[9..14]) + offset90k);
-        if (flags == 0x03 && payload.Length >= 19)
-            WritePesTimestamp(payload[14..19], ReadPesTimestamp(payload[14..19]) + offset90k);
-    }
-
-    private static void RewritePcrTimestamp(Span<byte> packet, long offset90k)
-    {
-        var adaptationControl = (packet[3] >> 4) & 0x03;
-        if ((adaptationControl & 0x02) == 0 || packet[4] < 7 || (packet[5] & 0x10) == 0)
-            return;
-        const long pcrBaseWrap = 1L << 33;
-        var pcr = packet[6..12];
-        var pcrBase = ((long)pcr[0] << 25) |
-                      ((long)pcr[1] << 17) |
-                      ((long)pcr[2] << 9) |
-                      ((long)pcr[3] << 1) |
-                      ((long)pcr[4] >> 7);
-        pcrBase = (pcrBase + offset90k) % pcrBaseWrap;
-        if (pcrBase < 0)
-            pcrBase += pcrBaseWrap;
-        pcr[0] = (byte)(pcrBase >> 25);
-        pcr[1] = (byte)(pcrBase >> 17);
-        pcr[2] = (byte)(pcrBase >> 9);
-        pcr[3] = (byte)(pcrBase >> 1);
-        pcr[4] = (byte)((pcr[4] & 0x7F) | (byte)((pcrBase & 1) << 7));
-    }
-
-    private static long ReadPesTimestamp(ReadOnlySpan<byte> value) =>
-        ((long)(value[0] & 0x0E) << 29) |
-        ((long)value[1] << 22) |
-        ((long)(value[2] & 0xFE) << 14) |
-        ((long)value[3] << 7) |
-        ((long)value[4] >> 1);
-
-    private static void WritePesTimestamp(Span<byte> value, long timestamp)
-    {
-        const long wrap = 1L << 33;
-        timestamp %= wrap;
-        if (timestamp < 0)
-            timestamp += wrap;
-        value[0] = (byte)((value[0] & 0xF0) | (byte)((timestamp >> 29) & 0x0E) | 1);
-        value[1] = (byte)(timestamp >> 22);
-        value[2] = (byte)(((timestamp >> 14) & 0xFE) | 1);
-        value[3] = (byte)(timestamp >> 7);
-        value[4] = (byte)(((timestamp << 1) & 0xFE) | 1);
     }
 
     internal static byte[] BuildPatSection(TsCheckResult catalog, HashSet<int> selectedPrograms)

--- a/src/TSCutter.GUI/Services/TsTimelineRepairService.cs
+++ b/src/TSCutter.GUI/Services/TsTimelineRepairService.cs
@@ -7,6 +7,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using TSCutter.GUI.Models;
+using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.Services;
 
@@ -14,7 +15,6 @@ public sealed class TsTimelineRepairService
 {
     private const int PacketSize = TsStreamAnalyzer.PacketSize;
     private const int ReadPacketCount = 32_768;
-    private const long TimestampWrap = 1L << 33;
     private const long BoundaryThreshold90k = 22_500;
     private const long PairMinimumTolerance90k = 9_000;
     private const double MaximumPairedDurationSeconds = 120;
@@ -143,17 +143,20 @@ public sealed class TsTimelineRepairService
                         throw new TsTimelineRepairException(TsTimelineRepairErrorCode.SyncLost, packetIndex);
                     var pid = ((packet[1] & 0x1F) << 8) | packet[2];
                     var transportError = (packet[1] & 0x80) != 0;
-                    if (!transportError && TryGetPcr(packet, out var rawPcr90k, out var pcrOffset, out var discontinuity))
+                    if (!transportError && TsTimestampFieldCodec.TryReadPcr(
+                            packet, out var rawPcr90k, out var pcrOffset, out var discontinuity))
                     {
                         var state = GetOutputPcrState(pcrStates, pid);
-                        var unwrapped = Unwrap(rawPcr90k, state.LastRawPcr90k, state.WrapOffset90k);
+                        var unwrapped = TsTimestampFieldCodec.UnwrapTimestamp(
+                            rawPcr90k, state.LastRawPcr90k, state.WrapOffset90k);
                         state.LastRawPcr90k = rawPcr90k;
                         state.WrapOffset90k = unwrapped - rawPcr90k;
                         var correction = FindCorrection(analysis.Segments, pid, packetIndex, unwrapped);
                         var corrected = unwrapped + correction;
                         if (correction != 0)
                         {
-                            WritePcrBase(packet.Slice(pcrOffset, 5), corrected);
+                            TsTimestampFieldCodec.WritePcrBase(
+                                packet.Slice(pcrOffset, 5), corrected);
                             rewrittenPcrCount++;
                         }
                         ValidateOutputPcr(state, corrected, discontinuity,
@@ -282,10 +285,12 @@ public sealed class TsTimelineRepairService
             var packetIndex = Math.Max(
                 0, (referenceFileOffset - _analysis.SyncOffset) / PacketSize);
             var pid = ((packet[1] & 0x1F) << 8) | packet[2];
-            if (TryGetPcr(packet, out var rawPcr90k, out var pcrOffset, out var discontinuity))
+            if (TsTimestampFieldCodec.TryReadPcr(
+                    packet, out var rawPcr90k, out var pcrOffset, out var discontinuity))
             {
                 var state = GetOutputPcrState(_pcrStates, pid);
-                var unwrapped = Unwrap(rawPcr90k, state.LastRawPcr90k, state.WrapOffset90k);
+                var unwrapped = TsTimestampFieldCodec.UnwrapTimestamp(
+                    rawPcr90k, state.LastRawPcr90k, state.WrapOffset90k);
                 state.LastRawPcr90k = rawPcr90k;
                 state.WrapOffset90k = unwrapped - rawPcr90k;
                 var correction = applyPcrCorrection
@@ -294,7 +299,7 @@ public sealed class TsTimelineRepairService
                 var corrected = unwrapped + correction;
                 if (correction != 0)
                 {
-                    WritePcrBase(packet.Slice(pcrOffset, 5), corrected);
+                    TsTimestampFieldCodec.WritePcrBase(packet.Slice(pcrOffset, 5), corrected);
                     RewrittenPcrCount++;
                 }
                 var errors = RemainingPcrErrorCount;
@@ -344,7 +349,8 @@ public sealed class TsTimelineRepairService
                     if (packet[0] != 0x47)
                         throw new TsTimelineRepairException(TsTimelineRepairErrorCode.SyncLost, packetIndex);
                     if ((packet[1] & 0x80) != 0 ||
-                        !TryGetPcr(packet, out var rawPcr90k, out _, out var discontinuity))
+                        !TsTimestampFieldCodec.TryReadPcr(
+                            packet, out var rawPcr90k, out _, out var discontinuity))
                     {
                         continue;
                     }
@@ -355,7 +361,8 @@ public sealed class TsTimelineRepairService
                         states[pid] = state;
                         result[pid] = [];
                     }
-                    var unwrapped = Unwrap(rawPcr90k, state.LastRawPcr90k, state.WrapOffset90k);
+                    var unwrapped = TsTimestampFieldCodec.UnwrapTimestamp(
+                        rawPcr90k, state.LastRawPcr90k, state.WrapOffset90k);
                     state.LastRawPcr90k = rawPcr90k;
                     state.WrapOffset90k = unwrapped - rawPcr90k;
                     result[pid].Add(new PcrSample(packetIndex, unwrapped, discontinuity));
@@ -641,35 +648,17 @@ public sealed class TsTimelineRepairService
         long packetIndex,
         List<TsTimelineCorrectionSegment> segments)
     {
-        if ((packet[1] & 0x40) == 0)
+        // 先确认当前包确实携带 PTS/DTS，再计算异常区段修正量，避免普通负载包
+        // 在高码率文件中反复遍历时间轴方案。
+        if (!TsTimestampFieldCodec.TryLocatePesTimestamps(
+                packet, out var ptsOffset, out var dtsOffset))
+        {
             return 0;
-        var adaptationControl = (packet[3] >> 4) & 3;
-        if ((adaptationControl & 1) == 0)
-            return 0;
-        var payloadOffset = 4;
-        if ((adaptationControl & 2) != 0)
-            payloadOffset += packet[4] + 1;
-        if (payloadOffset + 14 > PacketSize)
-            return 0;
-        var payload = packet[payloadOffset..];
-        if (payload[0] != 0 || payload[1] != 0 || payload[2] != 1 || payload.Length < 9)
-            return 0;
+        }
+
         var correction = FindTimestampCorrection(segments, packetIndex);
-        if (correction == 0)
-            return 0;
-        var flags = (payload[7] >> 6) & 3;
-        var count = 0;
-        if ((flags & 2) != 0 && payload.Length >= 14)
-        {
-            WritePesTimestamp(payload[9..14], ReadPesTimestamp(payload[9..14]) + correction);
-            count++;
-        }
-        if (flags == 3 && payload.Length >= 19)
-        {
-            WritePesTimestamp(payload[14..19], ReadPesTimestamp(payload[14..19]) + correction);
-            count++;
-        }
-        return count;
+        return TsTimestampFieldCodec.RewritePesTimestamps(
+            packet, correction, ptsOffset, dtsOffset);
     }
 
     private static long FindTimestampCorrection(List<TsTimelineCorrectionSegment> segments, long packetIndex)
@@ -712,58 +701,6 @@ public sealed class TsTimelineRepairService
         return correction;
     }
 
-    private static bool TryGetPcr(
-        ReadOnlySpan<byte> packet,
-        out long rawPcr90k,
-        out int pcrOffset,
-        out bool discontinuity)
-    {
-        rawPcr90k = 0;
-        pcrOffset = 0;
-        discontinuity = false;
-        var adaptationControl = (packet[3] >> 4) & 3;
-        if ((adaptationControl & 2) == 0 || packet[4] < 1)
-            return false;
-        var flags = packet[5];
-        discontinuity = (flags & 0x80) != 0;
-        if ((flags & 0x10) == 0 || packet[4] < 7)
-            return false;
-        pcrOffset = 6;
-        rawPcr90k = ((long)packet[6] << 25) |
-                    ((long)packet[7] << 17) |
-                    ((long)packet[8] << 9) |
-                    ((long)packet[9] << 1) |
-                    ((long)packet[10] >> 7);
-        return true;
-    }
-
-    private static void WritePcrBase(Span<byte> value, long pcr90k)
-    {
-        var raw = ModuloTimestamp(pcr90k);
-        value[0] = (byte)(raw >> 25);
-        value[1] = (byte)(raw >> 17);
-        value[2] = (byte)(raw >> 9);
-        value[3] = (byte)(raw >> 1);
-        value[4] = (byte)((value[4] & 0x7F) | (byte)((raw & 1) << 7));
-    }
-
-    private static long ReadPesTimestamp(ReadOnlySpan<byte> value) =>
-        ((long)(value[0] & 0x0E) << 29) |
-        ((long)value[1] << 22) |
-        ((long)(value[2] & 0xFE) << 14) |
-        ((long)value[3] << 7) |
-        ((long)value[4] >> 1);
-
-    private static void WritePesTimestamp(Span<byte> value, long timestamp90k)
-    {
-        var raw = ModuloTimestamp(timestamp90k);
-        value[0] = (byte)((value[0] & 0xF1) | (byte)(((raw >> 30) & 7) << 1));
-        value[1] = (byte)(raw >> 22);
-        value[2] = (byte)((((raw >> 15) & 0x7F) << 1) | 1);
-        value[3] = (byte)(raw >> 7);
-        value[4] = (byte)(((raw & 0x7F) << 1) | 1);
-    }
-
     private static void ValidateOutputPcr(
         OutputPcrState state,
         long correctedPcr90k,
@@ -793,24 +730,6 @@ public sealed class TsTimelineRepairService
 
     private static double EstimateTime(List<PcrSample> samples, int index, double ticksPerPacket) =>
         (samples[index].PacketIndex - samples[0].PacketIndex) * ticksPerPacket / 90_000.0;
-
-    private static long Unwrap(long raw, long lastRaw, long wrapOffset)
-    {
-        if (lastRaw != long.MinValue)
-        {
-            if (lastRaw - raw > TimestampWrap / 2)
-                wrapOffset += TimestampWrap;
-            else if (raw - lastRaw > TimestampWrap / 2)
-                wrapOffset -= TimestampWrap;
-        }
-        return raw + wrapOffset;
-    }
-
-    private static long ModuloTimestamp(long value)
-    {
-        value %= TimestampWrap;
-        return value < 0 ? value + TimestampWrap : value;
-    }
 
     private static void TryDelete(string path)
     {

--- a/src/TSCutter.GUI/Utils/TsTimestampFieldCodec.cs
+++ b/src/TSCutter.GUI/Utils/TsTimestampFieldCodec.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Runtime.CompilerServices;
+
+namespace TSCutter.GUI.Utils;
+
+/// <summary>
+/// 集中处理 TS 包内 PCR、PTS 和 DTS 的读取、回绕展开与安全改写。
+/// 上层服务只负责决定修正量，避免扫描、过滤和修复策略重复实现位字段操作。
+/// </summary>
+internal static class TsTimestampFieldCodec
+{
+    private const int PacketSize = TsUtil.TsPacketSize;
+    private const long TimestampWrap = 1L << 33;
+
+    public static bool TryReadPcr(
+        ReadOnlySpan<byte> packet,
+        out long rawPcr90k,
+        out int pcrOffset,
+        out bool discontinuity)
+    {
+        rawPcr90k = 0;
+        pcrOffset = 0;
+        discontinuity = false;
+        if (packet.Length < PacketSize)
+            return false;
+
+        var adaptationControl = (packet[3] >> 4) & 0x03;
+        if ((adaptationControl & 0x02) == 0 || packet[4] < 1)
+            return false;
+
+        var flags = packet[5];
+        discontinuity = (flags & 0x80) != 0;
+        if ((flags & 0x10) == 0 || packet[4] < 7)
+            return false;
+
+        pcrOffset = 6;
+        rawPcr90k = ReadPcrBase(packet[6..11]);
+        return true;
+    }
+
+    public static bool RewritePcr(Span<byte> packet, long correction90k)
+    {
+        if (correction90k == 0 ||
+            !TryReadPcr(packet, out var rawPcr90k, out var pcrOffset, out _))
+        {
+            return false;
+        }
+
+        WritePcrBase(packet.Slice(pcrOffset, 5), rawPcr90k + correction90k);
+        return true;
+    }
+
+    public static int RewritePesTimestamps(
+        Span<byte> packet,
+        long correction90k,
+        bool preserveFirstMarkerBit = true)
+    {
+        if ((correction90k == 0 && preserveFirstMarkerBit) ||
+            !TryLocatePesTimestamps(packet, out var ptsOffset, out var dtsOffset))
+        {
+            return 0;
+        }
+
+        return RewritePesTimestamps(
+            packet, correction90k, ptsOffset, dtsOffset, preserveFirstMarkerBit);
+    }
+
+    public static bool TryLocatePesTimestamps(
+        ReadOnlySpan<byte> packet,
+        out int ptsOffset,
+        out int dtsOffset)
+    {
+        ptsOffset = -1;
+        dtsOffset = -1;
+        if (packet.Length < PacketSize || (packet[1] & 0x40) == 0)
+            return false;
+
+        var adaptationControl = (packet[3] >> 4) & 0x03;
+        if ((adaptationControl & 0x01) == 0)
+            return false;
+
+        var payloadOffset = 4;
+        if ((adaptationControl & 0x02) != 0)
+            payloadOffset += packet[4] + 1;
+        if (payloadOffset + 14 > PacketSize)
+            return false;
+
+        var payload = packet[payloadOffset..];
+        if (payload.Length < 9 || payload[0] != 0 || payload[1] != 0 || payload[2] != 1)
+            return false;
+
+        var flags = (payload[7] >> 6) & 0x03;
+        if ((flags & 0x02) != 0 && payload.Length >= 14)
+            ptsOffset = payloadOffset + 9;
+        if (flags == 0x03 && payload.Length >= 19)
+            dtsOffset = payloadOffset + 14;
+        return ptsOffset >= 0;
+    }
+
+    public static int RewritePesTimestamps(
+        Span<byte> packet,
+        long correction90k,
+        int ptsOffset,
+        int dtsOffset,
+        bool preserveFirstMarkerBit = true)
+    {
+        if ((correction90k == 0 && preserveFirstMarkerBit) ||
+            ptsOffset < 0 || ptsOffset + 5 > packet.Length)
+            return 0;
+
+        var pts = packet.Slice(ptsOffset, 5);
+        WritePesTimestamp(
+            pts, ReadPesTimestamp(pts) + correction90k, preserveFirstMarkerBit);
+        var count = 1;
+        if (dtsOffset >= 0 && dtsOffset + 5 <= packet.Length)
+        {
+            var dts = packet.Slice(dtsOffset, 5);
+            WritePesTimestamp(
+                dts, ReadPesTimestamp(dts) + correction90k, preserveFirstMarkerBit);
+            count++;
+        }
+        return count;
+    }
+
+    public static void WritePcrBase(Span<byte> value, long pcr90k)
+    {
+        var raw = ModuloTimestamp(pcr90k);
+        value[0] = (byte)(raw >> 25);
+        value[1] = (byte)(raw >> 17);
+        value[2] = (byte)(raw >> 9);
+        value[3] = (byte)(raw >> 1);
+        // PCR extension 与保留位保持原值，只改写 33 位 PCR base。
+        value[4] = (byte)((value[4] & 0x7F) | (byte)((raw & 1) << 7));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static long ReadPcrBase(ReadOnlySpan<byte> value) =>
+        ((long)value[0] << 25) |
+        ((long)value[1] << 17) |
+        ((long)value[2] << 9) |
+        ((long)value[3] << 1) |
+        ((long)value[4] >> 7);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static long ReadPesTimestamp(ReadOnlySpan<byte> value) =>
+        ((long)(value[0] & 0x0E) << 29) |
+        ((long)value[1] << 22) |
+        ((long)(value[2] & 0xFE) << 14) |
+        ((long)value[3] << 7) |
+        ((long)value[4] >> 1);
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static long UnwrapTimestamp(long rawTimestamp, long lastRawTimestamp, long wrapOffset)
+    {
+        // 只有跨越半个 33 位周期才判定为回绕，不能吞掉普通的时间戳倒退异常。
+        if (lastRawTimestamp == long.MinValue)
+            return rawTimestamp + wrapOffset;
+        if (lastRawTimestamp - rawTimestamp > TimestampWrap / 2)
+            wrapOffset += TimestampWrap;
+        else if (rawTimestamp - lastRawTimestamp > TimestampWrap / 2)
+            wrapOffset -= TimestampWrap;
+        return rawTimestamp + wrapOffset;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static long UnwrapTimestamp(
+        long rawTimestamp,
+        ref long lastRawTimestamp,
+        ref long wrapOffset)
+    {
+        var unwrapped = UnwrapTimestamp(rawTimestamp, lastRawTimestamp, wrapOffset);
+        lastRawTimestamp = rawTimestamp;
+        wrapOffset = unwrapped - rawTimestamp;
+        return unwrapped;
+    }
+
+    private static void WritePesTimestamp(
+        Span<byte> value,
+        long timestamp90k,
+        bool preserveFirstMarkerBit)
+    {
+        var raw = ModuloTimestamp(timestamp90k);
+        // 时间轴修复默认保留首个 marker bit，以免顺带掩盖源文件中的格式错误；
+        // 由封包器生成输出时则可显式要求把该位规范为 1。
+        var preserved = preserveFirstMarkerBit
+            ? value[0] & 0xF1
+            : (value[0] & 0xF0) | 1;
+        value[0] = (byte)(preserved | (byte)(((raw >> 30) & 7) << 1));
+        value[1] = (byte)(raw >> 22);
+        value[2] = (byte)((((raw >> 15) & 0x7F) << 1) | 1);
+        value[3] = (byte)(raw >> 7);
+        value[4] = (byte)(((raw & 0x7F) << 1) | 1);
+    }
+
+    private static long ModuloTimestamp(long value)
+    {
+        value %= TimestampWrap;
+        return value < 0 ? value + TimestampWrap : value;
+    }
+}

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -58,6 +58,8 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         OnPropertyChanged(nameof(ZoomFactorStr));
         OnPropertyChanged(nameof(StatusInfoText));
+        OnPropertyChanged(nameof(SelectedClipsEstimatedSizeStr));
+        OnPropertyChanged(nameof(SelectedClipsDurationSummaryStr));
     }
 
     private long PositionInFile => _videoInstance!.PositionInFile;
@@ -82,6 +84,43 @@ public partial class MainWindowViewModel : ViewModelBase
     [ObservableProperty]
     public partial ObservableCollection<PickedClip> Clips { get; set; } = new();
 
+    // SelectedClip 表示用于编辑起止点的活动项；IsSelected 表示参与多选合并的集合。
+    private PickedClip? _clipSelectionAnchor;
+    public int SelectedClipCount => Clips.Count(clip => clip.IsSelected);
+    public IReadOnlyList<ClipTimelineRange> SelectedClipRanges => Clips
+        .Where(clip => clip.IsSelected)
+        .Select(clip => new ClipTimelineRange(
+            clip.StartTime,
+            clip.EndTime < 0 ? DurationMax : clip.EndTime,
+            ReferenceEquals(clip, SelectedClip)))
+        .ToArray();
+
+    public string SelectedClipsEstimatedSizeStr
+    {
+        get
+        {
+            var aggregate = GetSelectedClipAggregate();
+            return aggregate.Count == 0
+                ? string.Empty
+                : LocalizationManager.Instance.String_SizePrefix +
+                  CommonUtil.FormatFileSize(aggregate.Bytes);
+        }
+    }
+
+    public string SelectedClipsDurationSummaryStr
+    {
+        get
+        {
+            var aggregate = GetSelectedClipAggregate();
+            return aggregate.Count == 0
+                ? string.Empty
+                : string.Format(
+                    LocalizationManager.Instance.String_Clips_SelectionSummary,
+                    aggregate.Count,
+                    CommonUtil.FormatSeconds(aggregate.DurationSeconds));
+        }
+    }
+
     private long _queueIdCounter;
     private string? _lastQueueOutputDirectory;
     public ObservableCollection<ExportQueueItem> ExportQueue { get; } = new();
@@ -100,12 +139,104 @@ public partial class MainWindowViewModel : ViewModelBase
     partial void OnSelectedClipChanged(PickedClip? value)
     {
         foreach (var clip in Clips)
-            clip.IsSelected = clip == value;
+            clip.IsActive = ReferenceEquals(clip, value);
     }
-    
-    public void SelectClip(PickedClip clip)
+
+    public void SelectClip(PickedClip clip, KeyModifiers modifiers = KeyModifiers.None)
     {
-        SelectedClip = clip;
+        var toggle = modifiers.HasFlag(KeyModifiers.Control) ||
+                     modifiers.HasFlag(KeyModifiers.Meta);
+        if (modifiers.HasFlag(KeyModifiers.Shift) && _clipSelectionAnchor is not null)
+        {
+            var anchorIndex = Clips.IndexOf(_clipSelectionAnchor);
+            var targetIndex = Clips.IndexOf(clip);
+            if (anchorIndex >= 0 && targetIndex >= 0)
+            {
+                foreach (var item in Clips)
+                    item.IsSelected = false;
+                var start = Math.Min(anchorIndex, targetIndex);
+                var end = Math.Max(anchorIndex, targetIndex);
+                for (var index = start; index <= end; index++)
+                    Clips[index].IsSelected = true;
+                SelectedClip = clip;
+            }
+        }
+        else if (toggle)
+        {
+            clip.IsSelected = !clip.IsSelected;
+            if (clip.IsSelected)
+            {
+                SelectedClip = clip;
+                _clipSelectionAnchor = clip;
+            }
+            else if (ReferenceEquals(SelectedClip, clip))
+            {
+                SelectedClip = Clips.LastOrDefault(item => item.IsSelected);
+            }
+        }
+        else
+        {
+            foreach (var item in Clips)
+                item.IsSelected = ReferenceEquals(item, clip);
+            SelectedClip = clip;
+            _clipSelectionAnchor = clip;
+        }
+
+        NotifyClipSelectionChanged();
+    }
+
+    private void NotifyClipSelectionChanged()
+    {
+        OnPropertyChanged(nameof(SelectedClipCount));
+        OnPropertyChanged(nameof(SelectedClipRanges));
+        OnPropertyChanged(nameof(SelectedClipsEstimatedSizeStr));
+        OnPropertyChanged(nameof(SelectedClipsDurationSummaryStr));
+        MergeSelectedClipsCommand.NotifyCanExecuteChanged();
+    }
+
+    private (int Count, long Bytes, double DurationSeconds) GetSelectedClipAggregate()
+    {
+        var ranges = Clips
+            .Where(clip => clip.IsSelected)
+            .Select(clip => new ClipAggregateRange(
+                Math.Max(0, clip.StartPosition),
+                clip.EndPosition > 0
+                    ? Math.Min(clip.EndPosition, clip.InFileInfo.Length)
+                    : clip.InFileInfo.Length,
+                Math.Max(0, clip.StartTime),
+                clip.EndTime < 0 ? DurationMax : clip.EndTime))
+            .Where(range => range.EndPosition > range.StartPosition &&
+                            range.EndTime > range.StartTime)
+            .OrderBy(range => range.StartPosition)
+            .ToArray();
+        if (ranges.Length == 0)
+            return default;
+
+        long totalBytes = 0;
+        double totalDuration = 0;
+        var current = ranges[0];
+        for (var index = 1; index < ranges.Length; index++)
+        {
+            var next = ranges[index];
+            if (next.StartPosition > current.EndPosition)
+            {
+                totalBytes += current.EndPosition - current.StartPosition;
+                totalDuration += current.EndTime - current.StartTime;
+                current = next;
+                continue;
+            }
+
+            // 与实际合并服务保持一致：重叠剪辑只输出一次，大小和时长按并集统计。
+            current = current with
+            {
+                EndPosition = Math.Max(current.EndPosition, next.EndPosition),
+                EndTime = Math.Max(current.EndTime, next.EndTime)
+            };
+        }
+
+        totalBytes += current.EndPosition - current.StartPosition;
+        totalDuration += current.EndTime - current.StartTime;
+        return (ranges.Length, totalBytes, totalDuration);
     }
     
     [RelayCommand]
@@ -201,7 +332,7 @@ public partial class MainWindowViewModel : ViewModelBase
             EndTime = DurationMax,
         };
         Clips.Add(newClip);
-        SelectedClip = newClip;
+        SelectClip(newClip);
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]
@@ -210,8 +341,12 @@ public partial class MainWindowViewModel : ViewModelBase
         var index = Clips.ToList().FindIndex(x => x.ClipID == SelectedClip?.ClipID);
         if (index <= -1) return;
         
-        Clips.RemoveAt(index);   
-        SelectedClip = null;
+        var removed = Clips[index];
+        Clips.RemoveAt(index);
+        if (ReferenceEquals(_clipSelectionAnchor, removed))
+            _clipSelectionAnchor = null;
+        SelectedClip = Clips.LastOrDefault(item => item.IsSelected);
+        NotifyClipSelectionChanged();
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]
@@ -220,10 +355,12 @@ public partial class MainWindowViewModel : ViewModelBase
         SelectedClip!.StartTime = CurrentTime;
         SelectedClip!.StartPts = CurrentPts;
         SelectedClip!.StartPosition = PositionInFile;
-        if (!(SelectedClip!.EndTime <= CurrentTime)) return;
-        
-        SelectedClip!.EndTime = DurationMax;
-        SelectedClip!.EndPosition = -1;
+        if (SelectedClip!.EndTime <= CurrentTime)
+        {
+            SelectedClip!.EndTime = DurationMax;
+            SelectedClip!.EndPosition = -1;
+        }
+        NotifyClipSelectionChanged();
     }
 
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]
@@ -232,10 +369,12 @@ public partial class MainWindowViewModel : ViewModelBase
         SelectedClip!.EndTime = CurrentTime;
         SelectedClip!.EndPts = CurrentPts;
         SelectedClip!.EndPosition = PositionInFile;
-        if (!(SelectedClip!.StartTime >= CurrentTime)) return;
-        
-        SelectedClip!.StartTime = 0;
-        SelectedClip!.StartPosition = 0;
+        if (SelectedClip!.StartTime >= CurrentTime)
+        {
+            SelectedClip!.StartTime = 0;
+            SelectedClip!.StartPosition = 0;
+        }
+        NotifyClipSelectionChanged();
     }
 
     [RelayCommand]
@@ -348,6 +487,100 @@ public partial class MainWindowViewModel : ViewModelBase
 
     [RelayCommand(CanExecute = nameof(HasSelectedClip))]
     private async Task SaveVideoClickAsync() => await SaveVideoAsync();
+
+    [RelayCommand(CanExecute = nameof(CanMergeSelectedClips))]
+    private async Task MergeSelectedClipsAsync()
+    {
+        var selected = Clips
+            .Where(clip => clip.IsSelected)
+            .OrderBy(clip => clip.StartPosition)
+            .ToArray();
+        if (selected.Length < 2)
+            return;
+
+        var sourcePath = selected[0].InFileInfo.FullName;
+        var settings = new SaveFileDialogSettings
+        {
+            Title = LocalizationManager.Instance.String_MergeClips_Title,
+            SuggestedStartLocation = new DesktopDialogStorageFolder(
+                Path.GetDirectoryName(sourcePath)!),
+            SuggestedFileName = Path.GetFileNameWithoutExtension(sourcePath) + "_merged.ts",
+            Filters =
+            [
+                new(LocalizationManager.Instance.String_TsFiles, ["ts"]),
+                new(LocalizationManager.Instance.String_AllFiles, "*")
+            ],
+            DefaultExtension = "ts"
+        };
+        var result = await _dialogService.ShowSaveFileDialogAsync(this, settings);
+        if (result?.Path is null)
+            return;
+
+        var outputPath = result.Path.LocalPath;
+        if (PathsEqual(sourcePath, outputPath))
+        {
+            await ShowMessageAsync(
+                LocalizationManager.Instance.String_MergeClips_OutputMatchesSource,
+                LocalizationManager.Instance.String_Error,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        var request = new TsClipMergeRequest
+        {
+            SourcePath = sourcePath,
+            OutputPath = outputPath,
+            Ranges = selected.Select(clip => new TsClipMergeRange(
+                clip.StartPosition,
+                clip.EndPosition,
+                clip.StartTime,
+                clip.EndTime < 0 ? DurationMax : clip.EndTime)).ToArray()
+        };
+        var outputViewModel = _dialogService.CreateViewModel<OutputWindowViewModel>();
+        outputViewModel.SetMergeTask(request);
+        await _dialogService.ShowDialogAsync(this, outputViewModel).ConfigureAwait(true);
+        if (outputViewModel.Exception is not null)
+        {
+            await ShowMessageAsync(
+                FormatMergeError(outputViewModel.Exception),
+                LocalizationManager.Instance.String_Error,
+                MessageBoxIcon.Error);
+            return;
+        }
+
+        if (outputViewModel.DialogResult == true)
+        {
+            await ShowMessageAsync(
+                string.Format(
+                    LocalizationManager.Instance.String_MergeClips_Completed,
+                    outputPath),
+                LocalizationManager.Instance.String_MergeClips_Title,
+                MessageBoxIcon.Information);
+        }
+    }
+
+    private bool CanMergeSelectedClips => SelectedClipCount >= 2 &&
+                                          Clips.Where(clip => clip.IsSelected).All(clip =>
+                                              clip.EndTime > clip.StartTime &&
+                                              clip.StartPosition >= 0 &&
+                                              (clip.EndPosition < 0 ||
+                                               clip.EndPosition > clip.StartPosition));
+
+    private static string FormatMergeError(Exception exception)
+    {
+        if (exception is not TsClipMergeException mergeException)
+            return exception.Message;
+        return mergeException.Code switch
+        {
+            TsClipMergeErrorCode.OutputMatchesSource =>
+                LocalizationManager.Instance.String_MergeClips_OutputMatchesSource,
+            TsClipMergeErrorCode.NoSync =>
+                LocalizationManager.Instance.String_MergeClips_NoSync,
+            TsClipMergeErrorCode.InvalidRange =>
+                LocalizationManager.Instance.String_MergeClips_InvalidRange,
+            _ => LocalizationManager.Instance.String_MergeClips_SourceChanged
+        };
+    }
 
     [RelayCommand(CanExecute = nameof(IsVideoInitialized))]
     private void CloseVideoClick()
@@ -598,6 +831,8 @@ public partial class MainWindowViewModel : ViewModelBase
         DecodedBitmap = null;
         Clips.Clear();
         SelectedClip = null;
+        _clipSelectionAnchor = null;
+        NotifyClipSelectionChanged();
         DurationMax = 0.0;
         CurrentTime = 0.0;
         DecodeCost = 0L;
@@ -965,4 +1200,10 @@ public partial class MainWindowViewModel : ViewModelBase
             ThemeMenuItems.Add(menuItem);
         }
     }
+
+    private readonly record struct ClipAggregateRange(
+        long StartPosition,
+        long EndPosition,
+        double StartTime,
+        double EndTime);
 }

--- a/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/OutputWindowViewModel.cs
@@ -7,6 +7,8 @@ using System.Threading.Tasks;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using HanumanInstitute.MvvmDialogs;
+using TSCutter.GUI.Models;
+using TSCutter.GUI.Services;
 using TSCutter.GUI.Utils;
 
 namespace TSCutter.GUI.ViewModels;
@@ -41,6 +43,7 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     public partial string CancelButtonText { get; set; } = "";
 
     public bool IsBatchMode => _tasks.Count > 0;
+    public bool IsMergeMode => _mergeRequest is not null;
     public int TotalTasks => _tasks.Count;
     public double QueueProgress => TotalTasks > 0 ? CurrentTaskIndex * 100.0 / TotalTasks : 0;
     public string QueueProgressStr => $"{CurrentTaskIndex} / {TotalTasks}";
@@ -56,6 +59,7 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     public Exception? Exception { get; private set; }
     
     private readonly List<BatchTask> _tasks = [];
+    private TsClipMergeRequest? _mergeRequest;
     public List<int> CompletedTaskIndices { get; } = [];
     private CancellationTokenSource _cts = new();
     private DateTime _lastUpdateTime;
@@ -77,6 +81,12 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
         CancelButtonText = LocalizationManager.Instance.String_Output_CancelRemaining;
     }
 
+    internal void SetMergeTask(TsClipMergeRequest request)
+    {
+        _mergeRequest = request;
+        OnPropertyChanged(nameof(IsMergeMode));
+    }
+
     [RelayCommand]
     private async Task OutputAsync()
     {
@@ -84,9 +94,51 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
         {
             await RunBatchAsync();
         }
+        else if (IsMergeMode)
+        {
+            await RunMergeAsync();
+        }
         else
         {
             await RunSingleAsync();
+        }
+    }
+
+    private async Task RunMergeAsync()
+    {
+        var request = _mergeRequest;
+        if (request is null)
+            return;
+
+        try
+        {
+            CurrentFileName = Path.GetFileName(request.OutputPath);
+            var progress = new Progress<TsClipMergeProgress>(value =>
+            {
+                Percent = value.Percent;
+                Speed = value.BytesPerSecond;
+                RemainingSeconds = value.BytesPerSecond > 0
+                    ? Math.Max(0, value.TotalBytes - value.BytesProcessed) / value.BytesPerSecond
+                    : 0;
+            });
+            await new TsClipMergeService().MergeAsync(
+                request, progress, _cts.Token).ConfigureAwait(true);
+            Percent = 100;
+            RemainingSeconds = 0;
+            DialogResult = true;
+            RequestClose?.Invoke();
+        }
+        catch (OperationCanceledException)
+        {
+            Console.WriteLine("TS clip merge was canceled.");
+            DialogResult = false;
+            RequestClose?.Invoke();
+        }
+        catch (Exception exception)
+        {
+            Exception = exception;
+            DialogResult = false;
+            RequestClose?.Invoke();
         }
     }
 
@@ -208,6 +260,11 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
             _batchCancelled = true;
             _cts.Cancel();
         }
+        else if (IsMergeMode)
+        {
+            // 合并服务会在取消后删除半成品；等待清理完成再关闭窗口，避免主界面误报成功。
+            _cts.Cancel();
+        }
         else
         {
             _cts.Cancel();
@@ -218,6 +275,8 @@ public partial class OutputWindowViewModel : ViewModelBase, IModalDialogViewMode
     
     public void OnClosing(CancelEventArgs e)
     {
+        if (IsMergeMode && DialogResult is null)
+            e.Cancel = true;
         CancelOutput();
     }
 

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -108,6 +108,8 @@
                                   InputGesture="{OnPlatform Ctrl+S, macOS=⌘+S}" />
                         <MenuItem Header="{DynamicResource String.AddToQueue}"
                                   Command="{Binding AddToQueueCommand}" />
+                        <MenuItem Header="{DynamicResource String.MergeClips.Menu}"
+                                  Command="{Binding MergeSelectedClipsCommand}" />
                         <MenuItem Header="{DynamicResource String.Menu.ExportQueue}"
                                   Command="{Binding BatchExportQueueCommand}" />
                         <Separator />
@@ -288,12 +290,12 @@
                                                                         </Style>
                                                                     </Border.Styles>
                                                                     <Grid>
-                                                                        <!-- Unselected: Raised border -->
+                                                                        <!-- Inactive: Raised border -->
                                                                         <ClassicBorderDecorator BorderThickness="2" BorderStyle="Raised"
-                                                                                                IsVisible="{Binding IsSelected, Converter={x:Static local:App.InverseBoolConverter}}" />
-                                                                        <!-- Selected: Sunken border -->
+                                                                                                IsVisible="{Binding IsActive, Converter={x:Static local:App.InverseBoolConverter}}" />
+                                                                        <!-- Active editor: Sunken border -->
                                                                         <ClassicBorderDecorator BorderThickness="2" BorderStyle="Sunken"
-                                                                                                IsVisible="{Binding IsSelected}" />
+                                                                                                IsVisible="{Binding IsActive}" />
                                                                         <!-- Content -->
                                                                         <StackPanel Margin="4" Spacing="2">
                                                                             <!-- Header: ID + Status -->
@@ -483,6 +485,7 @@
                                                Value="{Binding CurrentTime, Mode=TwoWay}"
                                                RangeStart="{Binding SelectedClip.StartTime, FallbackValue=-1}"
                                                RangeEnd="{Binding SelectedClip.EndTime, FallbackValue=-1}"
+                                               Ranges="{Binding SelectedClipRanges}"
                                                ValueChangedAfterMouseUp="CustomSlider_OnValueChangedAfterMouseUp">
                             <controls:CustomSlider.Styles>
                                 <Style Selector="Thumb:pointerover /template/ Ellipse#SliderInnerThumb">
@@ -591,9 +594,27 @@
                                         <Setter Property="Opacity" Value="0.3" />
                                     </Style>
                                 </StackPanel.Styles>
-                                <!-- Estimated Size -->
-                                <TextBlock Text="{Binding SelectedClip.EstimatedSizeStr, Mode=OneWay}"
-                                           VerticalAlignment="Center" />
+                                <Grid Width="180"
+                                      Height="34"
+                                      RowDefinitions="16,18"
+                                      ClipToBounds="True"
+                                      VerticalAlignment="Center"
+                                      HorizontalAlignment="Right">
+                                    <TextBlock Grid.Row="0"
+                                               Text="{Binding SelectedClipsDurationSummaryStr}"
+                                               HorizontalAlignment="Right"
+                                               VerticalAlignment="Center"
+                                               TextAlignment="Right"
+                                               TextTrimming="CharacterEllipsis"
+                                               FontSize="11"
+                                               Foreground="{DynamicResource SystemControlForegroundBaseMediumBrush}" />
+                                    <TextBlock Grid.Row="1"
+                                               Text="{Binding SelectedClipsEstimatedSizeStr, Mode=OneWay}"
+                                               HorizontalAlignment="Right"
+                                               VerticalAlignment="Center"
+                                               TextTrimming="CharacterEllipsis"
+                                               TextAlignment="Right" />
+                                </Grid>
                                 <!-- Save Video Button -->
                                 <Button Command="{Binding SaveVideoClickCommand}"
                                         Classes="accent"

--- a/src/TSCutter.GUI/Views/MainWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml.cs
@@ -55,7 +55,7 @@ public partial class MainWindow : ClassicWindow
     {
         if (sender is Border { DataContext: PickedClip clip })
         {
-            ViewModel.SelectClip(clip);
+            ViewModel.SelectClip(clip, e.KeyModifiers);
         }
     }
 


### PR DESCRIPTION
## Overview

Adds a “Merge Selected Clips” feature that combines multiple ranges from the same source into a single continuous TS file.

## Changes

- Support multi-selection using Ctrl/Cmd and Shift
- Display all selected ranges on the main timeline
- Show the selected clip count, combined duration, and estimated size
- Merge overlapping ranges to avoid duplicate output
- Continuously adjust PCR, PTS, DTS, and continuity counters at clip boundaries
- Preserve existing packet loss, TEI, and continuity errors inside each clip
- Display output progress, speed, and remaining time with cancellation cleanup
- Extract shared TS timestamp field utilities for the scanner, stream filter, timeline repair, and multi-source repair services
- Add Simplified Chinese, Traditional Chinese, and English localization
- Stabilize the summary layout to prevent selection-related UI resizing

## Verification

- Release build completed successfully
- All 35 automated tests passed
- Tests cover timestamp wrapping, PCR/PTS/DTS rewriting, join continuity, overlapping ranges, and cancellation cleanup

---

## 概述

新增“合并选中剪辑”功能，可将同一源文件中的多个剪辑区间输出为一个连续的 TS 文件。

## 主要改动

- 支持通过 Ctrl/Cmd 和 Shift 多选剪辑
- 在主时间轴上同时展示所有选中区间
- 实时显示选中剪辑数量、合计时长和预计大小
- 重叠区间自动合并，避免重复输出
- 合并时连续化 PCR、PTS、DTS 和接缝处的连续计数器
- 保留剪辑内部原有的丢包、TEI 和连续计数异常，避免掩盖真实错误
- 支持输出进度、速度、剩余时间和取消清理
- 抽取公共 TS 时间戳字段工具，供快速扫描、流过滤、时间轴修复和多源修复复用
- 补充简体中文、繁体中文和英文文本
- 优化统计区域布局，避免选择状态变化引起界面抖动

## 验证

- Release 构建通过
- 35 项自动化测试全部通过
- 覆盖时间戳回绕、PCR/PTS/DTS 改写、接缝连续性、重叠区间及取消清理