### PR TITLE
Fix localized clip card text refresh after language switch

### DIFF
--- a/src/TSCutter.GUI.Tests/ClipLocalizationRefreshTests.cs
+++ b/src/TSCutter.GUI.Tests/ClipLocalizationRefreshTests.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.IO;
+using TSCutter.GUI.Models;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public sealed class ClipLocalizationRefreshTests
+{
+    [Fact]
+    public void PickedClipRefreshLocalizedTextNotifiesLocalizedDisplayProperties()
+    {
+        var clip = new PickedClip
+        {
+            InFileInfo = new FileInfo("sample.ts"),
+            StartPosition = 0,
+            EndPosition = 188
+        };
+        var changed = CollectChangedProperties(clip);
+
+        clip.RefreshLocalizedText();
+
+        Assert.Contains(nameof(PickedClip.EstimatedSizeStr), changed);
+        Assert.Contains(nameof(PickedClip.StatusText), changed);
+    }
+
+    [Fact]
+    public void ExportQueueItemRefreshLocalizedTextNotifiesLocalizedDisplayProperties()
+    {
+        var item = new ExportQueueItem();
+        var changed = CollectChangedProperties(item);
+
+        item.RefreshLocalizedText();
+
+        Assert.Contains(nameof(ExportQueueItem.EstimatedSizeStr), changed);
+        Assert.Contains(nameof(ExportQueueItem.StatusText), changed);
+    }
+
+    [Fact]
+    public void ExportQueueItemStatusChangeNotifiesStatusText()
+    {
+        var item = new ExportQueueItem();
+        var changed = CollectChangedProperties(item);
+
+        item.Status = ClipExportStatus.Done;
+
+        Assert.Contains(nameof(ExportQueueItem.Status), changed);
+        Assert.Contains(nameof(ExportQueueItem.StatusText), changed);
+    }
+
+    private static List<string> CollectChangedProperties(INotifyPropertyChanged source)
+    {
+        var changed = new List<string>();
+        source.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName is not null)
+                changed.Add(args.PropertyName);
+        };
+        return changed;
+    }
+}

--- a/src/TSCutter.GUI/Models/ExportQueueItem.cs
+++ b/src/TSCutter.GUI/Models/ExportQueueItem.cs
@@ -26,6 +26,7 @@ public partial class ExportQueueItem : ObservableObject
     public long EstimatedBytes { get; init; }
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusText))]
     private ClipExportStatus _status = ClipExportStatus.Pending;
 
     public string StatusText => Status switch
@@ -46,4 +47,10 @@ public partial class ExportQueueItem : ObservableObject
         + CommonUtil.FormatFileSize(Math.Max(0, EstimatedBytes));
 
     public string? OutputFilePathStr => OutputFilePath;
+
+    public void RefreshLocalizedText()
+    {
+        OnPropertyChanged(nameof(EstimatedSizeStr));
+        OnPropertyChanged(nameof(StatusText));
+    }
 }

--- a/src/TSCutter.GUI/Models/PickedClip.cs
+++ b/src/TSCutter.GUI/Models/PickedClip.cs
@@ -77,4 +77,10 @@ public partial class PickedClip : ObservableObject
         ClipExportStatus.Cancelled => LocalizationManager.Instance.String_Clips_Cancelled,
         _ => "---"
     };
+
+    public void RefreshLocalizedText()
+    {
+        OnPropertyChanged(nameof(EstimatedSizeStr));
+        OnPropertyChanged(nameof(StatusText));
+    }
 }

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -56,6 +56,12 @@ public partial class MainWindowViewModel : ViewModelBase
 
     private void OnLanguageChanged()
     {
+        // 集合项的计算属性不会随资源字典自动刷新，需要逐项通知界面重新取值。
+        foreach (var clip in Clips)
+            clip.RefreshLocalizedText();
+        foreach (var item in ExportQueue)
+            item.RefreshLocalizedText();
+
         OnPropertyChanged(nameof(ZoomFactorStr));
         OnPropertyChanged(nameof(StatusInfoText));
         OnPropertyChanged(nameof(SelectedClipEstimatedSizeStr));


### PR DESCRIPTION
## Overview

Fixes an issue where existing clip cards and export queue items retained text from the previous language after switching the application language. For example, the size label could remain in Chinese after switching to English.

## Changes

- Refresh localized computed properties for existing clip cards when the language changes.
- Refresh size and status text for existing export queue items.
- Notify the dependent status text binding when an export queue item's status changes.
- Add tests covering localized text refresh behavior for clip and queue models.

## Validation

- Release build completed successfully.
- All 59 tests passed.

---

## 概述

修复切换应用语言后，已有剪辑卡片和导出队列项目仍显示旧语言文本的问题。例如从中文切换到英文后，“大小”标签仍然显示为中文。

## 主要改动

- 语言切换时刷新已有剪辑卡片的本地化计算属性。
- 语言切换时刷新导出队列项目的大小和状态文本。
- 修复导出队列状态变化时未通知状态文本绑定的问题。
- 增加剪辑卡片和导出队列本地化刷新测试。

## 验证

- Release 构建通过。
- 全部 59 项测试通过。