### PR TITLE
Fix empty timeline when video stream duration is unavailable

### DIFF
--- a/src/TSCutter.GUI.Tests/VideoInstanceDurationTests.cs
+++ b/src/TSCutter.GUI.Tests/VideoInstanceDurationTests.cs
@@ -1,0 +1,52 @@
+using TSCutter.GUI.Models;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public sealed class VideoInstanceDurationTests
+{
+    [Fact]
+    public void UsesVideoStreamDurationWhenAvailable()
+    {
+        var duration = VideoInstance.ResolveTimelineDuration(
+            streamDuration: 900_000,
+            timeBaseNumerator: 1,
+            timeBaseDenominator: 90_000,
+            containerDuration: 12_000_000);
+
+        Assert.Equal(10, duration.Seconds, 6);
+        Assert.Equal(900_000, duration.StreamPts);
+    }
+
+    [Fact]
+    public void FallsBackToContainerDurationInStreamTimeBase()
+    {
+        var duration = VideoInstance.ResolveTimelineDuration(
+            streamDuration: 0,
+            timeBaseNumerator: 1,
+            timeBaseDenominator: 90_000,
+            containerDuration: 462_720_000);
+
+        Assert.Equal(462.72, duration.Seconds, 6);
+        Assert.Equal(41_644_800, duration.StreamPts);
+    }
+
+    [Theory]
+    [InlineData(0, 90_000, 10_000_000)]
+    [InlineData(1, 0, 10_000_000)]
+    [InlineData(1, 90_000, 0)]
+    public void ReturnsZeroWhenNoUsableDurationExists(
+        int timeBaseNumerator,
+        int timeBaseDenominator,
+        long containerDuration)
+    {
+        var duration = VideoInstance.ResolveTimelineDuration(
+            streamDuration: 0,
+            timeBaseNumerator,
+            timeBaseDenominator,
+            containerDuration);
+
+        Assert.Equal(0, duration.Seconds);
+        Assert.Equal(0, duration.StreamPts);
+    }
+}

--- a/src/TSCutter.GUI/Models/VideoInstance.cs
+++ b/src/TSCutter.GUI/Models/VideoInstance.cs
@@ -41,6 +41,8 @@ public class VideoInstance(string filePath) : IDisposable
     private long currentKeyFramePositionInFile;
     private long keyFrameGap;
     private long lastSeekPts;
+    private double timelineDurationSeconds;
+    private long timelineDurationPts;
     
     private string videoPath = filePath;
 
@@ -82,6 +84,7 @@ public class VideoInstance(string filePath) : IDisposable
         
         videoStreamIndex = inVideoStream.Index;
         timeBase = inVideoStream.TimeBase;
+        UpdateTimelineDuration();
 
         var firstDecoder = decoders.Last();
         videoDecoder = new(firstDecoder);
@@ -94,7 +97,7 @@ public class VideoInstance(string filePath) : IDisposable
             // calc KeyFrameGap from packet-level PTS (no frame decoding needed)
             var (firstPts, gap) = ReadKeyFramePacketPts();
             firstFrameTimestamp = firstPts;
-            maxPts = inVideoStream.Duration + firstFrameTimestamp;
+            maxPts = timelineDurationPts + firstFrameTimestamp;
             keyFrameGap = gap;
             Console.WriteLine($"keyFrameGap: {keyFrameGap}");
             Seek(firstFrameTimestamp);
@@ -125,6 +128,7 @@ public class VideoInstance(string filePath) : IDisposable
 
         videoStreamIndex = inVideoStream.Index;
         timeBase = inVideoStream.TimeBase;
+        UpdateTimelineDuration();
 
         var firstDecoder = decoders.First();
         videoDecoder = new(Codec.FindDecoderById(firstDecoder.Id));
@@ -251,16 +255,50 @@ public class VideoInstance(string filePath) : IDisposable
 
     public double GetVideoDurationInSeconds()
     {
-        return inVideoStream.GetDurationInSeconds();
+        return timelineDurationSeconds;
     }
 
     public string GetVideoInfoText()
     {
         var width = inVideoStream.Codecpar!.Width;
         var height = inVideoStream.Codecpar.Height;
-        var durationInSeconds = inVideoStream.GetDurationInSeconds();
         var fileSize = inFc.GetFileSize();
-        return $"{inVideoStream.Codecpar.CodecId}, {width}x{height}, {FormatSeconds(durationInSeconds)}, {FormatFileSize(fileSize)}";
+        return $"{inVideoStream.Codecpar.CodecId}, {width}x{height}, {FormatSeconds(timelineDurationSeconds)}, {FormatFileSize(fileSize)}";
+    }
+
+    private void UpdateTimelineDuration()
+    {
+        (timelineDurationSeconds, timelineDurationPts) = ResolveTimelineDuration(
+            inVideoStream.Duration,
+            timeBase.Num,
+            timeBase.Den,
+            inFc.Duration);
+    }
+
+    internal static (double Seconds, long StreamPts) ResolveTimelineDuration(
+        long streamDuration,
+        int timeBaseNumerator,
+        int timeBaseDenominator,
+        long containerDuration)
+    {
+        if (timeBaseNumerator <= 0 || timeBaseDenominator <= 0)
+            return default;
+
+        if (streamDuration > 0)
+        {
+            var seconds = streamDuration * timeBaseNumerator / (double)timeBaseDenominator;
+            return (seconds, streamDuration);
+        }
+
+        if (containerDuration <= 0)
+            return default;
+
+        // 部分异常 TS 缺少视频流时长，此时使用 FFmpeg 已估算出的容器时长作为回退。
+        var fallbackSeconds = containerDuration / (double)ffmpeg.AV_TIME_BASE;
+        var fallbackPts = (long)Math.Round(
+            fallbackSeconds * timeBaseDenominator / timeBaseNumerator,
+            MidpointRounding.AwayFromZero);
+        return (fallbackSeconds, fallbackPts);
     }
 
     /// <summary>
@@ -327,7 +365,7 @@ public class VideoInstance(string filePath) : IDisposable
                 if (firstFrameTimestamp == -1)
                 {
                     firstFrameTimestamp = frame.BestEffortTimestamp;
-                    maxPts = inVideoStream.Duration + firstFrameTimestamp;
+                    maxPts = timelineDurationPts + firstFrameTimestamp;
                 }
 
 #pragma warning disable CS0618 // Obsolete


### PR DESCRIPTION
## Overview

Fixes an issue where the main timeline was initialized with a zero duration for TS files whose video stream did not expose a valid duration.

## Changes

- Prefer the video stream duration when available
- Fall back to the container duration when the video duration is unavailable
- Apply the resolved duration consistently to the timeline, status bar, and seek boundary
- Preserve the existing duration path for normal files
- Add tests for duration selection and stream time-base conversion

## Verification

- Release build passed
- All 64 unit tests passed
- Verified timeline rendering and initial frame decoding with a TS file lacking video stream duration

---

## 概述

修复部分 TS 文件的视频流未提供有效时长时，主界面时间轴被错误初始化为空的问题。

## 改动

- 优先使用视频流自身的有效时长
- 视频流时长缺失时回退到容器时长
- 将回退时长同步用于时间轴、状态栏和跳转边界
- 保持正常文件原有的时长计算路径
- 增加时长选择和时间基换算测试

## 验证

- Release 构建通过
- 64 项单元测试全部通过
- 已使用视频流时长缺失的 TS 文件验证时间轴显示和首帧解码