### PR TITLE
Add TS anomaly navigation workflow

### DIFF
--- a/src/TSCutter.GUI.Tests/TsAnomalyNavigationUtilTests.cs
+++ b/src/TSCutter.GUI.Tests/TsAnomalyNavigationUtilTests.cs
@@ -1,0 +1,112 @@
+using TSCutter.GUI.Models;
+using TSCutter.GUI.Utils;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public sealed class TsAnomalyNavigationUtilTests
+{
+    [Fact]
+    public void SampleRangeUsesMeasuredTransportBitrate()
+    {
+        var result = CreateResult(100_000);
+        result.Pids.Add(0x0100, new TsCheckPidSummary
+        {
+            Pid = 0x0100,
+            Bitrate = TsUtil.TsPacketSize * 8 * 1_000
+        });
+        var item = CreateEvent(50_000, 50_010);
+
+        var range = TsAnomalyNavigationUtil.CalculateSampleRange(result, item);
+
+        Assert.Equal(35_000, range.StartPacket);
+        Assert.Equal(65_010, range.EndPacket);
+    }
+
+    [Fact]
+    public void SampleRangeFallsBackToTimelinePacketRate()
+    {
+        var result = CreateResult(100_000);
+        result.Timeline.Add(new TsCheckTimelineBucket
+        {
+            StartSeconds = 0,
+            DurationSeconds = 10,
+            TotalPacketCount = 20_000,
+            Segment = 0
+        });
+        var item = CreateEvent(50_000, 50_010);
+
+        var range = TsAnomalyNavigationUtil.CalculateSampleRange(result, item);
+
+        Assert.Equal(20_000, range.StartPacket);
+        Assert.Equal(80_010, range.EndPacket);
+    }
+
+    [Fact]
+    public void SampleRangeCoversMergedEventAndClampsToFile()
+    {
+        var result = CreateResult(20_000);
+        result.Pids.Add(0x0100, new TsCheckPidSummary
+        {
+            Pid = 0x0100,
+            Bitrate = TsUtil.TsPacketSize * 8 * 1_000
+        });
+        var item = CreateEvent(500, 19_500);
+
+        var range = TsAnomalyNavigationUtil.CalculateSampleRange(result, item);
+
+        Assert.Equal(0, range.StartPacket);
+        Assert.Equal(19_999, range.EndPacket);
+    }
+
+    [Fact]
+    public void SampleRangeUsesBoundedByteFallbackWithoutClockData()
+    {
+        const long totalPackets = 500_000;
+        var result = CreateResult(totalPackets);
+        var item = CreateEvent(200_000, 200_010);
+        var fallbackPackets = (16L * 1024 * 1024 + TsUtil.TsPacketSize - 1) / TsUtil.TsPacketSize;
+
+        var range = TsAnomalyNavigationUtil.CalculateSampleRange(result, item);
+
+        Assert.Equal(200_000 - fallbackPackets, range.StartPacket);
+        Assert.Equal(200_010 + fallbackPackets, range.EndPacket);
+    }
+
+    [Fact]
+    public void SampleRangeCanExtendPastCancelledScanPosition()
+    {
+        var result = CreateResult(100_000);
+        result.PacketCount = 50_000;
+        result.Pids.Add(0x0100, new TsCheckPidSummary
+        {
+            Pid = 0x0100,
+            Bitrate = TsUtil.TsPacketSize * 8 * 1_000
+        });
+        var item = CreateEvent(49_000, 49_010);
+
+        var range = TsAnomalyNavigationUtil.CalculateSampleRange(result, item);
+
+        Assert.Equal(34_000, range.StartPacket);
+        Assert.Equal(64_010, range.EndPacket);
+    }
+
+    private static TsCheckResult CreateResult(long packetCount) => new()
+    {
+        FilePath = "sample.ts",
+        FileSize = packetCount * TsUtil.TsPacketSize,
+        SyncOffset = 0,
+        PacketCount = packetCount
+    };
+
+    private static TsCheckEvent CreateEvent(long startPacket, long endPacket) => new()
+    {
+        Severity = TsCheckSeverity.Error,
+        Type = TsCheckEventType.ContinuityGap,
+        Pid = 0x0100,
+        StartPacket = startPacket,
+        EndPacket = endPacket,
+        FileOffset = startPacket * TsUtil.TsPacketSize,
+        MessageCode = TsCheckMessageCode.ContinuityGap
+    };
+}

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -418,6 +418,11 @@
     <x:String x:Key="String.TsCheck.Warnings">Warnings:</x:String>
     <x:String x:Key="String.TsCheck.Start">Scan Again</x:String>
     <x:String x:Key="String.TsCheck.Export">Export Report</x:String>
+    <x:String x:Key="String.TsCheck.Location.OpenPacketViewer">Open in Packet Viewer</x:String>
+    <x:String x:Key="String.TsCheck.Location.OpenRawCutter">Extract Nearby Sample...</x:String>
+    <x:String x:Key="String.TsCheck.Location.Copy">Copy Location</x:String>
+    <x:String x:Key="String.TsCheck.Location.Copied">Anomaly location copied to the clipboard.</x:String>
+    <x:String x:Key="String.TsCheck.Location.CopyFailed">Unable to access the clipboard.</x:String>
     <x:String x:Key="String.TsCheck.Column.Severity">Severity</x:String>
     <x:String x:Key="String.TsCheck.Column.SourceTime">Source time</x:String>
     <x:String x:Key="String.TsCheck.Column.ZeroBasedTime">0-based time</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -418,6 +418,11 @@
     <x:String x:Key="String.TsCheck.Warnings">警告：</x:String>
     <x:String x:Key="String.TsCheck.Start">重新扫描</x:String>
     <x:String x:Key="String.TsCheck.Export">导出报告</x:String>
+    <x:String x:Key="String.TsCheck.Location.OpenPacketViewer">在包查看器中打开</x:String>
+    <x:String x:Key="String.TsCheck.Location.OpenRawCutter">截取异常附近...</x:String>
+    <x:String x:Key="String.TsCheck.Location.Copy">复制定位信息</x:String>
+    <x:String x:Key="String.TsCheck.Location.Copied">异常定位信息已复制到剪贴板。</x:String>
+    <x:String x:Key="String.TsCheck.Location.CopyFailed">无法访问剪贴板。</x:String>
     <x:String x:Key="String.TsCheck.Column.Severity">级别</x:String>
     <x:String x:Key="String.TsCheck.Column.SourceTime">源时间点</x:String>
     <x:String x:Key="String.TsCheck.Column.ZeroBasedTime">0-based 时间</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -418,6 +418,11 @@
     <x:String x:Key="String.TsCheck.Warnings">警告：</x:String>
     <x:String x:Key="String.TsCheck.Start">重新掃描</x:String>
     <x:String x:Key="String.TsCheck.Export">匯出報告</x:String>
+    <x:String x:Key="String.TsCheck.Location.OpenPacketViewer">在包檢視器中開啟</x:String>
+    <x:String x:Key="String.TsCheck.Location.OpenRawCutter">擷取異常附近...</x:String>
+    <x:String x:Key="String.TsCheck.Location.Copy">複製定位資訊</x:String>
+    <x:String x:Key="String.TsCheck.Location.Copied">異常定位資訊已複製到剪貼簿。</x:String>
+    <x:String x:Key="String.TsCheck.Location.CopyFailed">無法存取剪貼簿。</x:String>
     <x:String x:Key="String.TsCheck.Column.Severity">等級</x:String>
     <x:String x:Key="String.TsCheck.Column.SourceTime">來源時間點</x:String>
     <x:String x:Key="String.TsCheck.Column.ZeroBasedTime">0-based 時間</x:String>

--- a/src/TSCutter.GUI/Utils/TsAnomalyNavigationUtil.cs
+++ b/src/TSCutter.GUI/Utils/TsAnomalyNavigationUtil.cs
@@ -1,0 +1,61 @@
+using System;
+using TSCutter.GUI.Models;
+
+namespace TSCutter.GUI.Utils;
+
+internal static class TsAnomalyNavigationUtil
+{
+    internal const double SampleContextSeconds = 15;
+    private const long FallbackContextBytes = 16L * 1024 * 1024;
+
+    public static TsPacketRange CalculateSampleRange(TsCheckResult result, TsCheckEvent item)
+    {
+        var packetsFromFileSize = result.SyncOffset >= 0
+            ? Math.Max(0, (result.FileSize - result.SyncOffset) / TsUtil.TsPacketSize)
+            : 0;
+        var totalPackets = Math.Max(result.PacketCount, packetsFromFileSize);
+        if (totalPackets == 0)
+            return new TsPacketRange(0, 0);
+
+        var lastPacket = totalPackets - 1;
+        var eventStart = Math.Clamp(item.StartPacket, 0, lastPacket);
+        var eventEnd = Math.Clamp(Math.Max(item.StartPacket, item.EndPacket), eventStart, lastPacket);
+        var packetsPerSecond = EstimatePacketsPerSecond(result);
+        var contextPackets = packetsPerSecond > 0
+            ? (long)Math.Min(totalPackets, Math.Ceiling(packetsPerSecond * SampleContextSeconds))
+            : Math.Min(totalPackets, (FallbackContextBytes + TsUtil.TsPacketSize - 1) / TsUtil.TsPacketSize);
+
+        // 合并后的异常可能横跨大量包，范围必须覆盖完整事件，再分别向前、向后补充上下文。
+        return new TsPacketRange(
+            Math.Max(0, eventStart - contextPackets),
+            Math.Min(lastPacket, eventEnd + contextPackets));
+    }
+
+    private static double EstimatePacketsPerSecond(TsCheckResult result)
+    {
+        double totalBitrate = 0;
+        foreach (var pid in result.Pids.Values)
+        {
+            if (double.IsFinite(pid.Bitrate) && pid.Bitrate > 0)
+                totalBitrate += pid.Bitrate;
+        }
+        if (totalBitrate > 0)
+            return totalBitrate / (TsUtil.TsPacketSize * 8.0);
+
+        double timelinePackets = 0;
+        double timelineSeconds = 0;
+        foreach (var bucket in result.Timeline)
+        {
+            if (!double.IsFinite(bucket.DurationSeconds) || bucket.DurationSeconds <= 0 ||
+                !double.IsFinite(bucket.TotalPacketCount) || bucket.TotalPacketCount <= 0)
+            {
+                continue;
+            }
+            timelinePackets += bucket.TotalPacketCount;
+            timelineSeconds += bucket.DurationSeconds;
+        }
+        return timelineSeconds > 0 ? timelinePackets / timelineSeconds : 0;
+    }
+}
+
+internal readonly record struct TsPacketRange(long StartPacket, long EndPacket);

--- a/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/RawCutterWindowViewModel.cs
@@ -214,6 +214,11 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
     /// </summary>
     public void Initialize(string filePath)
     {
+        Initialize(filePath, null);
+    }
+
+    internal void Initialize(string filePath, TsPacketRange? initialRange)
+    {
         FilePath = filePath;
         var fileInfo = new FileInfo(filePath);
         FileSize = fileInfo.Length;
@@ -221,9 +226,18 @@ public partial class RawCutterWindowViewModel : ViewModelBase, IModalDialogViewM
         SyncOffset = TsUtil.FindSyncOffset(filePath);
         TotalPackets = TsUtil.CountPackets(filePath, SyncOffset);
 
-        EndPacket = Math.Max(0, TotalPackets - 1);
-        StartOffset = TsUtil.PacketToOffset(StartPacket, SyncOffset);
-        EndOffset = PacketEndOffset(EndPacket);
+        var lastPacket = Math.Max(0, TotalPackets - 1);
+        var startPacket = Math.Clamp(initialRange?.StartPacket ?? 0, 0, lastPacket);
+        var endPacket = Math.Clamp(initialRange?.EndPacket ?? lastPacket, startPacket, lastPacket);
+
+        // 联动入口直接设置包范围，避免逐个属性的回调在初始化期间互相覆盖预选值。
+        _syncingSlider = true;
+        IsPacketMode = true;
+        StartPacket = startPacket;
+        EndPacket = endPacket;
+        StartOffset = TsUtil.PacketToOffset(startPacket, SyncOffset);
+        EndOffset = PacketEndOffset(endPacket);
+        _syncingSlider = false;
     }
 
     partial void OnStartPacketChanged(long value)

--- a/src/TSCutter.GUI/ViewModels/TsCheckWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsCheckWindowViewModel.cs
@@ -3,8 +3,11 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls.ApplicationLifetimes;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using HanumanInstitute.MvvmDialogs;
@@ -106,20 +109,30 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
     private TsCheckEvent? _selectedTimelineEvent;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(CanLocateSelectedEvent))]
+    [NotifyPropertyChangedFor(nameof(CanCopySelectedLocation))]
+    [NotifyCanExecuteChangedFor(nameof(OpenSelectedInPacketViewerCommand),
+        nameof(OpenSelectedInRawCutterCommand), nameof(CopySelectedLocationCommand))]
     private TsCheckEventView? _selectedEventRow;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanStart))]
     [NotifyPropertyChangedFor(nameof(CanCancel))]
     [NotifyPropertyChangedFor(nameof(CanRepairTimeline))]
+    [NotifyPropertyChangedFor(nameof(CanLocateSelectedEvent))]
+    [NotifyPropertyChangedFor(nameof(CanCopySelectedLocation))]
     [NotifyCanExecuteChangedFor(nameof(StartCommand), nameof(CancelCommand), nameof(ExportCommand),
-        nameof(RepairTimelineCommand))]
+        nameof(RepairTimelineCommand), nameof(OpenSelectedInPacketViewerCommand),
+        nameof(OpenSelectedInRawCutterCommand), nameof(CopySelectedLocationCommand))]
     private bool _isScanning;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(CanExport))]
     [NotifyPropertyChangedFor(nameof(CanRepairTimeline))]
-    [NotifyCanExecuteChangedFor(nameof(ExportCommand))]
+    [NotifyPropertyChangedFor(nameof(CanLocateSelectedEvent))]
+    [NotifyPropertyChangedFor(nameof(CanCopySelectedLocation))]
+    [NotifyCanExecuteChangedFor(nameof(ExportCommand), nameof(OpenSelectedInPacketViewerCommand),
+        nameof(OpenSelectedInRawCutterCommand), nameof(CopySelectedLocationCommand))]
     [NotifyCanExecuteChangedFor(nameof(RepairTimelineCommand))]
     private bool _hasResult;
 
@@ -181,6 +194,10 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
     public bool CanStart => !IsScanning;
     public bool CanCancel => IsScanning;
     public bool CanExport => HasResult && !IsScanning;
+    public bool CanLocateSelectedEvent => HasResult && !IsScanning &&
+                                           SelectedEventRow is not null && File.Exists(FilePath) &&
+                                           _result is { SyncOffset: >= 0, PacketCount: > 0 };
+    public bool CanCopySelectedLocation => HasResult && !IsScanning && SelectedEventRow is not null;
     // 只有快速扫描确认存在可进一步分析的 PCR 间隔偏差时，才显示修复入口；
     // 单纯因 TEI/丢包导致的估算时间轴只提供说明，避免把传输错误误导成可修复的时钟问题。
     // 显式 discontinuity 也可能让图表采用估算横轴，但它本身不是错误。
@@ -453,6 +470,67 @@ public partial class TsCheckWindowViewModel : ViewModelBase, IModalDialogViewMod
 
     [RelayCommand(CanExecute = nameof(CanCancel))]
     private void Cancel() => _cancellationTokenSource?.Cancel();
+
+    [RelayCommand(CanExecute = nameof(CanLocateSelectedEvent))]
+    private void OpenSelectedInPacketViewer()
+    {
+        var item = SelectedEventRow?.Item;
+        if (item is null)
+            return;
+
+        var viewModel = _dialogService.CreateViewModel<TsPacketViewerWindowViewModel>();
+        viewModel.Initialize(FilePath, item.StartPacket);
+        _dialogService.Show(null, viewModel);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanLocateSelectedEvent))]
+    private void OpenSelectedInRawCutter()
+    {
+        var result = _result;
+        var item = SelectedEventRow?.Item;
+        if (result is null || item is null)
+            return;
+
+        var range = TsAnomalyNavigationUtil.CalculateSampleRange(result, item);
+        var viewModel = _dialogService.CreateViewModel<RawCutterWindowViewModel>();
+        viewModel.Initialize(FilePath, range);
+        _dialogService.Show(null, viewModel);
+    }
+
+    [RelayCommand(CanExecute = nameof(CanCopySelectedLocation))]
+    private async Task CopySelectedLocationAsync()
+    {
+        var row = SelectedEventRow;
+        if (row is null)
+            return;
+
+        try
+        {
+            if (Application.Current?.ApplicationLifetime is not IClassicDesktopStyleApplicationLifetime desktop ||
+                desktop.MainWindow?.Clipboard is not { } clipboard)
+            {
+                StatusText = _text.Strings.String_TsCheck_Location_CopyFailed;
+                return;
+            }
+
+            var strings = _text.Strings;
+            var builder = new StringBuilder(256);
+            builder.Append(strings.String_TsCheck_Report_File).Append(": ").AppendLine(FilePath);
+            builder.Append(row.Severity).Append(" · ").AppendLine(row.Type);
+            builder.AppendLine(string.Format(
+                strings.String_TsCheck_Report_EventTimes, row.SourceTime, row.ZeroBasedTime));
+            builder.AppendLine(string.Format(
+                strings.String_TsCheck_Report_EventLocation,
+                row.Pid, row.Stream, row.Packet, row.Item.FileOffset));
+            builder.Append(row.Message);
+            await clipboard.SetTextAsync(builder.ToString());
+            StatusText = strings.String_TsCheck_Location_Copied;
+        }
+        catch
+        {
+            StatusText = _text.Strings.String_TsCheck_Location_CopyFailed;
+        }
+    }
 
     [RelayCommand(CanExecute = nameof(CanExport))]
     private async Task ExportAsync()

--- a/src/TSCutter.GUI/ViewModels/TsPacketViewerWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/TsPacketViewerWindowViewModel.cs
@@ -24,6 +24,7 @@ public partial class TsPacketViewerWindowViewModel : ViewModelBase, IModalDialog
     private readonly TsPacketViewerService _service = new();
     private CancellationTokenSource? _cancellationTokenSource;
     private TsPacketViewerSession? _session;
+    private long? _initialPacketIndex;
     private bool _isClosing;
     private int _generation;
 
@@ -92,10 +93,16 @@ public partial class TsPacketViewerWindowViewModel : ViewModelBase, IModalDialog
 
     public event Action<TsPacketViewerRow>? SelectionRequested;
 
+    public void Initialize(string filePath, long packetIndex)
+    {
+        FilePath = filePath;
+        _initialPacketIndex = Math.Max(0, packetIndex);
+    }
+
     public async Task InitializeAsync()
     {
         if (!string.IsNullOrEmpty(FilePath))
-            await OpenPathAsync(FilePath).ConfigureAwait(true);
+            await OpenPathAsync(FilePath, _initialPacketIndex).ConfigureAwait(true);
     }
 
     [RelayCommand(CanExecute = nameof(CanOpenFile))]
@@ -174,7 +181,7 @@ public partial class TsPacketViewerWindowViewModel : ViewModelBase, IModalDialog
     private bool CanMoveNextWindow() =>
         CanNavigate && SelectedPacket!.PacketIndex < _session!.TotalPackets - 1;
 
-    private async Task OpenPathAsync(string path)
+    private async Task OpenPathAsync(string path, long? initialPacketIndex = null)
     {
         var generation = ++_generation;
         var cancellation = ReplaceCancellation();
@@ -198,7 +205,9 @@ public partial class TsPacketViewerWindowViewModel : ViewModelBase, IModalDialog
                 session.SyncOffset.ToString("N0"),
                 session.TotalPackets.ToString("N0"));
             OnPropertyChanged(nameof(WindowTitle));
-            await LoadAroundCoreAsync(0, generation, cancellation.Token).ConfigureAwait(true);
+            // 快速检查传入的是扫描时的 0-based 包号；文件边界变化时仍在当前会话范围内安全收敛。
+            var targetPacket = Math.Clamp(initialPacketIndex ?? 0, 0, Math.Max(0, session.TotalPackets - 1));
+            await LoadAroundCoreAsync(targetPacket, generation, cancellation.Token).ConfigureAwait(true);
             StatusText = LocalizationManager.Instance.String_TsPacketViewer_Status_Ready;
         }
         catch (OperationCanceledException)

--- a/src/TSCutter.GUI/Views/TsCheckWindow.axaml
+++ b/src/TSCutter.GUI/Views/TsCheckWindow.axaml
@@ -173,25 +173,38 @@
             </DataGrid.Columns>
         </DataGrid>
 
-        <DataGrid Grid.Row="4" ItemsSource="{Binding Events}" IsReadOnly="True" AutoGenerateColumns="False"
-                  x:Name="DetailsGrid"
-                  IsVisible="{Binding IsDetailsView}"
-                  SelectedItem="{Binding SelectedEventRow, Mode=TwoWay}"
-                  GridLinesVisibility="All" CanUserResizeColumns="True"
-                  HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Auto"
-                  ScrollViewer.HorizontalScrollBarVisibility="Visible"
-                  ScrollViewer.VerticalScrollBarVisibility="Auto">
-            <DataGrid.Columns>
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Severity}" Binding="{Binding Severity}" Width="90" />
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.SourceTime}" Binding="{Binding SourceTime}" Width="120" />
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.ZeroBasedTime}" Binding="{Binding ZeroBasedTime}" Width="120" />
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Type}" Binding="{Binding Type}" Width="175" />
-                <DataGridTextColumn Header="PID" Binding="{Binding Pid}" Width="80" />
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Stream}" Binding="{Binding Stream}" Width="220" />
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Packet}" Binding="{Binding Packet}" Width="135" />
-                <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Description}" Binding="{Binding Message}" Width="420" />
-            </DataGrid.Columns>
-        </DataGrid>
+        <Grid Grid.Row="4" IsVisible="{Binding IsDetailsView}" RowDefinitions="*,Auto">
+            <DataGrid Grid.Row="0" ItemsSource="{Binding Events}" IsReadOnly="True" AutoGenerateColumns="False"
+                      x:Name="DetailsGrid"
+                      SelectedItem="{Binding SelectedEventRow, Mode=TwoWay}"
+                      DoubleTapped="DetailsGrid_OnDoubleTapped"
+                      GridLinesVisibility="All" CanUserResizeColumns="True"
+                      HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Auto"
+                      ScrollViewer.HorizontalScrollBarVisibility="Visible"
+                      ScrollViewer.VerticalScrollBarVisibility="Auto">
+                <DataGrid.Columns>
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Severity}" Binding="{Binding Severity}" Width="90" />
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.SourceTime}" Binding="{Binding SourceTime}" Width="120" />
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.ZeroBasedTime}" Binding="{Binding ZeroBasedTime}" Width="120" />
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Type}" Binding="{Binding Type}" Width="175" />
+                    <DataGridTextColumn Header="PID" Binding="{Binding Pid}" Width="80" />
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Stream}" Binding="{Binding Stream}" Width="220" />
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Packet}" Binding="{Binding Packet}" Width="135" />
+                    <DataGridTextColumn Header="{DynamicResource String.TsCheck.Column.Description}" Binding="{Binding Message}" Width="420" />
+                </DataGrid.Columns>
+            </DataGrid>
+            <ClassicBorderDecorator Grid.Row="1" Margin="0,6,0,0" BorderThickness="1"
+                                    BorderStyle="Etched" Padding="6,4">
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button Content="{DynamicResource String.TsCheck.Location.OpenPacketViewer}"
+                            Command="{Binding OpenSelectedInPacketViewerCommand}" MinWidth="145" />
+                    <Button Content="{DynamicResource String.TsCheck.Location.OpenRawCutter}"
+                            Command="{Binding OpenSelectedInRawCutterCommand}" MinWidth="135" />
+                    <Button Content="{DynamicResource String.TsCheck.Location.Copy}"
+                            Command="{Binding CopySelectedLocationCommand}" MinWidth="115" />
+                </StackPanel>
+            </ClassicBorderDecorator>
+        </Grid>
 
         <Grid Grid.Row="4" IsVisible="{Binding IsTimelineView}" RowDefinitions="Auto,*" RowSpacing="6">
             <Grid Grid.Row="0" ColumnDefinitions="Auto,360,*" ColumnSpacing="8">

--- a/src/TSCutter.GUI/Views/TsCheckWindow.axaml.cs
+++ b/src/TSCutter.GUI/Views/TsCheckWindow.axaml.cs
@@ -1,4 +1,5 @@
 using System;
+using Avalonia.Input;
 using Avalonia.Threading;
 using Classic.Avalonia.Theme;
 using TSCutter.GUI.Controls;
@@ -40,5 +41,14 @@ public partial class TsCheckWindow : ClassicWindow
             if (DataContext is TsCheckWindowViewModel { SelectedEventRow: { } row })
                 DetailsGrid.ScrollIntoView(row, null);
         }, DispatcherPriority.Loaded);
+    }
+
+    private void DetailsGrid_OnDoubleTapped(object? sender, TappedEventArgs eventArgs)
+    {
+        if (DataContext is TsCheckWindowViewModel viewModel &&
+            viewModel.OpenSelectedInPacketViewerCommand.CanExecute(null))
+        {
+            viewModel.OpenSelectedInPacketViewerCommand.Execute(null);
+        }
     }
 }


### PR DESCRIPTION
## Overview

Adds an anomaly navigation workflow to TS Quick Check, allowing scan results to be opened directly for packet-level inspection or nearby sample extraction.

## Changes

- Add anomaly navigation actions to the Quick Check detail view
- Open the selected anomaly directly in TS Packet Viewer
- Support double-clicking an anomaly to open Packet Viewer
- Open Raw Stream Cutter with a range around the selected anomaly
- Cover the complete merged anomaly interval with additional context on both sides
- Copy anomaly times, PID, packet range, byte offset, and description
- Allow Packet Viewer and Raw Stream Cutter to open at an initial location
- Add English, Simplified Chinese, and Traditional Chinese localization

## Performance and Compatibility

- Does not modify the per-packet Quick Check hot path
- Does not retain additional per-packet data
- Preserves the existing initialization APIs and default behavior
- Safely clamps navigation ranges to the current file boundaries

## Tests

- Added anomaly range calculation tests
- Release test suite passed: 114/114


---

## 概述

为 TS 快速检查增加异常定位工作流，方便从扫描结果直接进入包级分析或截取异常附近的样本。

## 主要改动

- 在快速检查详情视图中增加异常定位操作
- 支持在 TS 包查看器中直接打开异常对应的数据包
- 支持双击异常记录快速进入包查看器
- 支持在原始流截取工具中打开异常附近的范围
- 截取范围完整覆盖合并后的异常区间，并在前后保留上下文
- 支持复制异常时间、PID、数据包编号、字节偏移和描述信息
- 包查看器和原始流截取工具支持通过初始位置打开
- 补充英文、简体中文和繁体中文本地化资源

## 性能与兼容性

- 不修改快速检查的逐包扫描热路径
- 不额外保存逐包数据
- 保留现有工具的原始初始化入口和默认行为
- 定位范围会根据文件边界进行安全限制

## 测试

- 增加异常范围计算测试
- Release 测试通过：114/114