### PR TITLE
Add clip boundary thumbnails

### DIFF
--- a/src/TSCutter.GUI.Tests/ClipLocalizationRefreshTests.cs
+++ b/src/TSCutter.GUI.Tests/ClipLocalizationRefreshTests.cs
@@ -49,6 +49,24 @@ public sealed class ClipLocalizationRefreshTests
         Assert.Contains(nameof(ExportQueueItem.StatusText), changed);
     }
 
+    [Fact]
+    public void PickedClipTimeChangesRefreshBoundaryText()
+    {
+        var clip = new PickedClip
+        {
+            InFileInfo = new FileInfo("sample.ts")
+        };
+        var changed = CollectChangedProperties(clip);
+
+        clip.StartTime = 1.25;
+        clip.EndTime = 2.5;
+
+        Assert.Equal("[ 00:00:01.250", clip.StartBoundaryTimeStr);
+        Assert.Equal("00:00:02.500 ]", clip.EndBoundaryTimeStr);
+        Assert.Contains(nameof(PickedClip.StartBoundaryTimeStr), changed);
+        Assert.Contains(nameof(PickedClip.EndBoundaryTimeStr), changed);
+    }
+
     private static List<string> CollectChangedProperties(INotifyPropertyChanged source)
     {
         var changed = new List<string>();

--- a/src/TSCutter.GUI.Tests/ImageUtilTests.cs
+++ b/src/TSCutter.GUI.Tests/ImageUtilTests.cs
@@ -1,0 +1,40 @@
+using Avalonia;
+using TSCutter.GUI.Utils;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public sealed class ImageUtilTests
+{
+    [Theory]
+    [InlineData(7680, 4320, 0, 0, 160, 90)]
+    [InlineData(1920, 1080, 0, 0, 160, 90)]
+    [InlineData(1440, 1080, 20, 0, 120, 90)]
+    [InlineData(3840, 1600, 0, 11.666667, 160, 66.666667)]
+    [InlineData(1080, 1920, 54.6875, 0, 50.625, 90)]
+    public void CalculateAspectFitRectPreservesSourceAspectRatio(
+        double sourceWidth,
+        double sourceHeight,
+        double expectedX,
+        double expectedY,
+        double expectedWidth,
+        double expectedHeight)
+    {
+        var result = ImageUtil.CalculateAspectFitRect(
+            new Size(sourceWidth, sourceHeight),
+            new Size(160, 90));
+
+        Assert.Equal(expectedX, result.X, 5);
+        Assert.Equal(expectedY, result.Y, 5);
+        Assert.Equal(expectedWidth, result.Width, 5);
+        Assert.Equal(expectedHeight, result.Height, 5);
+    }
+
+    [Fact]
+    public void CalculateAspectFitRectRejectsInvalidSourceSize()
+    {
+        var result = ImageUtil.CalculateAspectFitRect(new Size(0, 1080), new Size(160, 90));
+
+        Assert.Equal(default, result);
+    }
+}

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -47,8 +47,6 @@
     <x:String x:Key="String.ToolBar.SaveFrame">Capture</x:String>
     <x:String x:Key="String.ToolBar.MediaInfoTip">Show Media Info</x:String>
     <x:String x:Key="String.ToolBar.MediaInfo">Info</x:String>
-    <x:String x:Key="String.Table.StartTime">Start Time</x:String>
-    <x:String x:Key="String.Table.EndTime">End Time</x:String>
     <x:String x:Key="String.Table.OutputSize">Output Size</x:String>
     <x:String x:Key="String.Table.OutputPath">Output Path</x:String>
     <x:String x:Key="String.Table.Status">Status</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -47,8 +47,6 @@
     <x:String x:Key="String.ToolBar.SaveFrame">截图</x:String>
     <x:String x:Key="String.ToolBar.MediaInfoTip">显示媒体信息</x:String>
     <x:String x:Key="String.ToolBar.MediaInfo">信息</x:String>
-    <x:String x:Key="String.Table.StartTime">开始时间</x:String>
-    <x:String x:Key="String.Table.EndTime">结束时间</x:String>
     <x:String x:Key="String.Table.OutputSize">输出大小</x:String>
     <x:String x:Key="String.Table.OutputPath">输出路径</x:String>
     <x:String x:Key="String.Table.Status">状态</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -47,8 +47,6 @@
     <x:String x:Key="String.ToolBar.SaveFrame">截圖</x:String>
     <x:String x:Key="String.ToolBar.MediaInfoTip">顯示媒體資訊</x:String>
     <x:String x:Key="String.ToolBar.MediaInfo">資訊</x:String>
-    <x:String x:Key="String.Table.StartTime">開始時間</x:String>
-    <x:String x:Key="String.Table.EndTime">結束時間</x:String>
     <x:String x:Key="String.Table.OutputSize">輸出大小</x:String>
     <x:String x:Key="String.Table.OutputPath">輸出路徑</x:String>
     <x:String x:Key="String.Table.Status">狀態</x:String>

--- a/src/TSCutter.GUI/Models/ExportQueueItem.cs
+++ b/src/TSCutter.GUI/Models/ExportQueueItem.cs
@@ -39,9 +39,9 @@ public partial class ExportQueueItem : ObservableObject
 
     public string OutputFileName => Path.GetFileName(OutputFilePath);
 
-    public string StartTimeStr => CommonUtil.FormatSeconds(StartTimeSeconds);
+    public string StartBoundaryTimeStr => $"[ {CommonUtil.FormatSeconds(StartTimeSeconds)}";
 
-    public string EndTimeStr => CommonUtil.FormatSeconds(EndTimeSeconds);
+    public string EndBoundaryTimeStr => $"{CommonUtil.FormatSeconds(EndTimeSeconds)} ]";
 
     public string EstimatedSizeStr => LocalizationManager.Instance.String_SizePrefix
         + CommonUtil.FormatFileSize(Math.Max(0, EstimatedBytes));

--- a/src/TSCutter.GUI/Models/PickedClip.cs
+++ b/src/TSCutter.GUI/Models/PickedClip.cs
@@ -1,6 +1,7 @@
 using System;
 using System.IO;
 using System.Threading;
+using Avalonia.Media.Imaging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using TSCutter.GUI.Utils;
 
@@ -15,7 +16,7 @@ public enum ClipExportStatus
     Cancelled
 }
 
-public partial class PickedClip : ObservableObject
+public partial class PickedClip : ObservableObject, IDisposable
 {
     private static long _idCounter = 0;
     public long ClipID { get; } = Interlocked.Increment(ref _idCounter);
@@ -24,11 +25,11 @@ public partial class PickedClip : ObservableObject
     public long EndPts {get; set;}
     
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(StartTimeStr))]
+    [NotifyPropertyChangedFor(nameof(StartBoundaryTimeStr))]
     private double _startTime = 0;
     
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(EndTimeStr))]
+    [NotifyPropertyChangedFor(nameof(EndBoundaryTimeStr))]
     private double _endTime = -1.0;
     
     [ObservableProperty]
@@ -57,12 +58,20 @@ public partial class PickedClip : ObservableObject
     [ObservableProperty]
     private bool _isActive;
 
+    private Bitmap? _startThumbnail;
+    private Bitmap? _endThumbnail;
+
+    public Bitmap? StartThumbnail => _startThumbnail;
+    public Bitmap? EndThumbnail => _endThumbnail;
+    public bool HasStartThumbnail => _startThumbnail is not null;
+    public bool HasEndThumbnail => _endThumbnail is not null;
+
     public required FileInfo InFileInfo { get; init; }
 
-    public string StartTimeStr => CommonUtil.FormatSeconds(StartTime);
+    public string StartBoundaryTimeStr => $"[ {CommonUtil.FormatSeconds(StartTime)}";
     public string? OutputFileSizeStr => OutputFileInfo == null ? null : CommonUtil.FormatFileSize(OutputFileInfo.Length);
     public string? OutputFilePathStr => OutputFileInfo?.FullName;
-    public string EndTimeStr => EndTime < 0 ? "Inf." : CommonUtil.FormatSeconds(EndTime);
+    public string EndBoundaryTimeStr => $"{(EndTime < 0 ? "Inf." : CommonUtil.FormatSeconds(EndTime))} ]";
     public string? EstimatedSizeStr => LocalizationManager.Instance.String_SizePrefix
         + CommonUtil.FormatFileSize(
             Math.Max(0, (EndPosition > 0 ? EndPosition : InFileInfo.Length) - StartPosition)
@@ -82,5 +91,33 @@ public partial class PickedClip : ObservableObject
     {
         OnPropertyChanged(nameof(EstimatedSizeStr));
         OnPropertyChanged(nameof(StatusText));
+    }
+
+    internal void ReplaceStartThumbnail(Bitmap? thumbnail)
+    {
+        if (ReferenceEquals(_startThumbnail, thumbnail))
+            return;
+
+        _startThumbnail?.Dispose();
+        _startThumbnail = thumbnail;
+        OnPropertyChanged(nameof(StartThumbnail));
+        OnPropertyChanged(nameof(HasStartThumbnail));
+    }
+
+    internal void ReplaceEndThumbnail(Bitmap? thumbnail)
+    {
+        if (ReferenceEquals(_endThumbnail, thumbnail))
+            return;
+
+        _endThumbnail?.Dispose();
+        _endThumbnail = thumbnail;
+        OnPropertyChanged(nameof(EndThumbnail));
+        OnPropertyChanged(nameof(HasEndThumbnail));
+    }
+
+    public void Dispose()
+    {
+        ReplaceStartThumbnail(null);
+        ReplaceEndThumbnail(null);
     }
 }

--- a/src/TSCutter.GUI/Utils/ImageUtil.cs
+++ b/src/TSCutter.GUI/Utils/ImageUtil.cs
@@ -64,6 +64,53 @@ public static class ImageUtil
         return writableBitmap;
     }
 
+    public static Bitmap CreateThumbnail(Bitmap source, int width = 160, int height = 90)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(width);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(height);
+
+        var thumbnail = new RenderTargetBitmap(new PixelSize(width, height), new Vector(96, 96));
+        try
+        {
+            using var context = thumbnail.CreateDrawingContext(true);
+            context.FillRectangle(Brushes.Black, new Rect(0, 0, width, height));
+
+            var sourceSize = source.Size;
+            if (sourceSize.Width <= 0 || sourceSize.Height <= 0)
+                return thumbnail;
+
+            var targetRect = CalculateAspectFitRect(sourceSize, new Size(width, height));
+            context.DrawImage(source, new Rect(sourceSize), targetRect);
+            return thumbnail;
+        }
+        catch
+        {
+            thumbnail.Dispose();
+            throw;
+        }
+    }
+
+    internal static Rect CalculateAspectFitRect(Size sourceSize, Size targetSize)
+    {
+        if (sourceSize.Width <= 0 || sourceSize.Height <= 0 ||
+            targetSize.Width <= 0 || targetSize.Height <= 0)
+        {
+            return default;
+        }
+
+        // 缩略图按原始比例居中，非 16:9 画面保留黑边而不裁剪内容。
+        var scale = Math.Min(
+            targetSize.Width / sourceSize.Width,
+            targetSize.Height / sourceSize.Height);
+        var width = sourceSize.Width * scale;
+        var height = sourceSize.Height * scale;
+        return new Rect(
+            (targetSize.Width - width) / 2,
+            (targetSize.Height - height) / 2,
+            width,
+            height);
+    }
+
     private static Bitmap CreateAudioBitmap(int width = 1920, int height = 1080)
     {
         var bitmap = new RenderTargetBitmap(new PixelSize(width, height), new Vector(96, 96));

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -250,6 +250,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         if (time is PickedClip { StartTime: > -1 } pickedClip)
         {
+            SelectClip(pickedClip);
             await JumpToTimeAsync(pickedClip.StartPts);
         }
     }
@@ -257,8 +258,9 @@ public partial class MainWindowViewModel : ViewModelBase
     [RelayCommand]
     private async Task JumpToEndTimeAsync(object? time)
     {
-        if (time is PickedClip { EndTime: > -1 } pickedClip)
+        if (time is PickedClip { EndTime: > -1, EndPosition: >= 0 } pickedClip)
         {
+            SelectClip(pickedClip);
             await JumpToTimeAsync(pickedClip.EndPts);
         }
     }
@@ -337,6 +339,7 @@ public partial class MainWindowViewModel : ViewModelBase
             StartPts = CurrentPts,
             EndTime = DurationMax,
         };
+        newClip.ReplaceStartThumbnail(CreateCurrentFrameThumbnail());
         Clips.Add(newClip);
         SelectClip(newClip);
     }
@@ -349,6 +352,7 @@ public partial class MainWindowViewModel : ViewModelBase
         
         var removed = Clips[index];
         Clips.RemoveAt(index);
+        removed.Dispose();
         if (ReferenceEquals(_clipSelectionAnchor, removed))
             _clipSelectionAnchor = null;
         SelectedClip = Clips.LastOrDefault(item => item.IsSelected);
@@ -361,10 +365,12 @@ public partial class MainWindowViewModel : ViewModelBase
         SelectedClip!.StartTime = CurrentTime;
         SelectedClip!.StartPts = CurrentPts;
         SelectedClip!.StartPosition = PositionInFile;
+        SelectedClip!.ReplaceStartThumbnail(CreateCurrentFrameThumbnail());
         if (SelectedClip!.EndTime <= CurrentTime)
         {
             SelectedClip!.EndTime = DurationMax;
             SelectedClip!.EndPosition = -1;
+            SelectedClip!.ReplaceEndThumbnail(null);
         }
         NotifyClipSelectionChanged();
     }
@@ -375,13 +381,19 @@ public partial class MainWindowViewModel : ViewModelBase
         SelectedClip!.EndTime = CurrentTime;
         SelectedClip!.EndPts = CurrentPts;
         SelectedClip!.EndPosition = PositionInFile;
+        SelectedClip!.ReplaceEndThumbnail(CreateCurrentFrameThumbnail());
         if (SelectedClip!.StartTime >= CurrentTime)
         {
             SelectedClip!.StartTime = 0;
             SelectedClip!.StartPosition = 0;
+            SelectedClip!.ReplaceStartThumbnail(null);
         }
         NotifyClipSelectionChanged();
     }
+
+    private Bitmap? CreateCurrentFrameThumbnail() => DecodedBitmap is { } bitmap
+        ? ImageUtil.CreateThumbnail(bitmap)
+        : null;
 
     [RelayCommand]
     private async Task RawCutterClickAsync()
@@ -895,6 +907,7 @@ public partial class MainWindowViewModel : ViewModelBase
     {
         VideoInfoText = PleaseLoadTip;
         DecodedBitmap = null;
+        DisposeClipThumbnails();
         Clips.Clear();
         SelectedClip = null;
         _clipSelectionAnchor = null;
@@ -1016,10 +1029,17 @@ public partial class MainWindowViewModel : ViewModelBase
 
     public void Close()
     {
+        DisposeClipThumbnails();
         _videoInstance?.Close();
         _videoInstance?.Dispose();
         _videoInstance = null;
         VideoPath = string.Empty;
+    }
+
+    private void DisposeClipThumbnails()
+    {
+        foreach (var clip in Clips)
+            clip.Dispose();
     }
 
     private bool HasSelectedClip => SelectedClip is not null;

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -78,11 +78,15 @@
                         <SolidColorBrush x:Key="MaskBackgroundBrush">White</SolidColorBrush>
                         <SolidColorBrush x:Key="ClipSelectionBackgroundBrush"
                                          Color="{DynamicResource SystemAccentColorLight1}" />
+                        <SolidColorBrush x:Key="ClipThumbnailBackgroundBrush" Color="#303236" />
+                        <SolidColorBrush x:Key="ClipThumbnailPlaceholderBrush" Color="#D8DADD" />
                     </ResourceDictionary>
                     <ResourceDictionary x:Key="Dark">
                         <SolidColorBrush x:Key="MaskBackgroundBrush" Color="#111316" />
                         <!-- 选中卡片只做轻微蓝色染色，避免与标题栏、进度条争夺视觉焦点。 -->
                         <SolidColorBrush x:Key="ClipSelectionBackgroundBrush" Color="#2B3B4B" />
+                        <SolidColorBrush x:Key="ClipThumbnailBackgroundBrush" Color="#111316" />
+                        <SolidColorBrush x:Key="ClipThumbnailPlaceholderBrush" Color="#969DA5" />
                     </ResourceDictionary>
                 </ResourceDictionary.ThemeDictionaries>
             </ResourceDictionary>
@@ -245,7 +249,7 @@
                                                       Command="{Binding ShowMediaInfoClickCommand}" />
                     </commonControls:ToolBar>
                     <Grid Grid.Row="1" RowDefinitions="*, Auto, Auto">
-                        <Grid Grid.Row="0" ColumnDefinitions="*, Auto, 190">
+                        <Grid Grid.Row="0" ColumnDefinitions="*, Auto, 240">
                             <!-- 图片预览区域 -->
                             <ClassicBorderDecorator Grid.Column="0" BorderThickness="0, 2" BorderStyle="Etched">
                                 <controls:ImageViewer Name="ImageViewer"
@@ -311,39 +315,72 @@
                                                                         <ClassicBorderDecorator BorderThickness="2" BorderStyle="Sunken"
                                                                                                 IsVisible="{Binding IsActive}" />
                                                                         <!-- Content -->
-                                                                        <StackPanel Margin="4" Spacing="2">
+                                                                        <Grid Margin="4"
+                                                                              RowDefinitions="Auto,64,Auto,Auto"
+                                                                              ColumnDefinitions="*,8,*">
                                                                             <!-- Header: ID + Status -->
-                                                                            <Grid ColumnDefinitions="Auto,*,Auto">
+                                                                            <Grid Grid.Row="0" Grid.ColumnSpan="3"
+                                                                                  ColumnDefinitions="Auto,*,Auto">
                                                                                 <TextBlock Text="{Binding ClipID, StringFormat='#{0}'}"
                                                                                            FontWeight="Bold"
                                                                                            FontSize="12" />
                                                                                 <TextBlock Grid.Column="2"
                                                                                            Text="{Binding StatusText}" />
                                                                             </Grid>
-                                                                            <!-- Start time -->
-                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
-                                                                                <TextBlock Text="{DynamicResource String.Table.StartTime}"
-                                                                                           Margin="0,0,4,0"
-                                                                                           VerticalAlignment="Center" />
-                                                                                <Button Grid.Column="1"
-                                                                                        Content="{Binding StartTimeStr}"
-                                                                                        Classes="hyperlink"
-                                                                                        Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
-                                                                                        CommandParameter="{Binding}" />
-                                                                            </Grid>
-                                                                            <!-- End time -->
-                                                                            <Grid ColumnDefinitions="Auto,*">
-                                                                                <TextBlock Text="{DynamicResource String.Table.EndTime}"
-                                                                                           Margin="0,0,4,0"
-                                                                                           VerticalAlignment="Center" />
-                                                                                <Button Grid.Column="1"
-                                                                                        Content="{Binding EndTimeStr}"
-                                                                                        Classes="hyperlink"
-                                                                                        Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
-                                                                                        CommandParameter="{Binding}" />
-                                                                            </Grid>
+                                                                            <Button Grid.Row="1" Grid.Column="0" Padding="2"
+                                                                                    MinWidth="0"
+                                                                                    HorizontalContentAlignment="Stretch"
+                                                                                    VerticalContentAlignment="Stretch"
+                                                                                    IsEnabled="{Binding HasStartThumbnail}"
+                                                                                    Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
+                                                                                    CommandParameter="{Binding}">
+                                                                                <Grid Background="{DynamicResource ClipThumbnailBackgroundBrush}"
+                                                                                      ClipToBounds="True">
+                                                                                    <Image Source="{Binding StartThumbnail}"
+                                                                                           Stretch="Uniform" />
+                                                                                    <TextBlock Text="—"
+                                                                                               IsVisible="{Binding HasStartThumbnail, Converter={x:Static local:App.InverseBoolConverter}}"
+                                                                                               Foreground="{DynamicResource ClipThumbnailPlaceholderBrush}"
+                                                                                               HorizontalAlignment="Center"
+                                                                                               VerticalAlignment="Center" />
+                                                                                </Grid>
+                                                                            </Button>
+                                                                            <Button Grid.Row="1" Grid.Column="2" Padding="2"
+                                                                                    MinWidth="0"
+                                                                                    HorizontalContentAlignment="Stretch"
+                                                                                    VerticalContentAlignment="Stretch"
+                                                                                    IsEnabled="{Binding HasEndThumbnail}"
+                                                                                    Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
+                                                                                    CommandParameter="{Binding}">
+                                                                                <Grid Background="{DynamicResource ClipThumbnailBackgroundBrush}"
+                                                                                      ClipToBounds="True">
+                                                                                    <Image Source="{Binding EndThumbnail}"
+                                                                                           Stretch="Uniform" />
+                                                                                    <TextBlock Text="—"
+                                                                                               IsVisible="{Binding HasEndThumbnail, Converter={x:Static local:App.InverseBoolConverter}}"
+                                                                                               Foreground="{DynamicResource ClipThumbnailPlaceholderBrush}"
+                                                                                               HorizontalAlignment="Center"
+                                                                                               VerticalAlignment="Center" />
+                                                                                </Grid>
+                                                                            </Button>
+
+                                                                            <Button Grid.Row="2" Grid.Column="0"
+                                                                                    Content="{Binding StartBoundaryTimeStr}"
+                                                                                    Classes="hyperlink"
+                                                                                    HorizontalAlignment="Center"
+                                                                                    IsEnabled="{Binding HasStartThumbnail}"
+                                                                                    Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToStartTimeCommand}"
+                                                                                    CommandParameter="{Binding}" />
+                                                                            <Button Grid.Row="2" Grid.Column="2"
+                                                                                    Content="{Binding EndBoundaryTimeStr}"
+                                                                                    Classes="hyperlink"
+                                                                                    HorizontalAlignment="Center"
+                                                                                    IsEnabled="{Binding HasEndThumbnail}"
+                                                                                    Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).JumpToEndTimeCommand}"
+                                                                                    CommandParameter="{Binding}" />
                                                                             <!-- Size + Output Path -->
-                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
+                                                                            <Grid Grid.Row="3" Grid.ColumnSpan="3"
+                                                                                  ColumnDefinitions="Auto,*" Margin="0,2,0,0">
                                                                                 <TextBlock Text="{Binding EstimatedSizeStr}"
                                                                                            VerticalAlignment="Center"
                                                                                            Margin="0,0,8,0" />
@@ -355,7 +392,7 @@
                                                                                         Command="{Binding #CutterMainWindow.((vm:MainWindowViewModel)DataContext).FindFileCommand}"
                                                                                         CommandParameter="{Binding OutputFileInfo}" />
                                                                             </Grid>
-                                                                        </StackPanel>
+                                                                        </Grid>
                                                                     </Grid>
                                                                 </Border>
                                                             </DataTemplate>
@@ -439,21 +476,11 @@
                                                                                        TextTrimming="CharacterEllipsis"
                                                                                        FontWeight="Bold"
                                                                                        FontSize="12" />
-                                                                            <!-- Start time -->
-                                                                            <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">
-                                                                                <TextBlock Text="{DynamicResource String.Table.StartTime}"
-                                                                                           Margin="0,0,4,0"
-                                                                                           VerticalAlignment="Center" />
-                                                                                <TextBlock Grid.Column="1"
-                                                                                           Text="{Binding StartTimeStr}" />
-                                                                            </Grid>
-                                                                            <!-- End time -->
-                                                                            <Grid ColumnDefinitions="Auto,*">
-                                                                                <TextBlock Text="{DynamicResource String.Table.EndTime}"
-                                                                                           Margin="0,0,4,0"
-                                                                                           VerticalAlignment="Center" />
-                                                                                <TextBlock Grid.Column="1"
-                                                                                           Text="{Binding EndTimeStr}" />
+                                                                            <!-- Boundary times -->
+                                                                            <Grid ColumnDefinitions="Auto,*,Auto" Margin="0,2,0,0">
+                                                                                <TextBlock Text="{Binding StartBoundaryTimeStr}" />
+                                                                                <TextBlock Grid.Column="2"
+                                                                                           Text="{Binding EndBoundaryTimeStr}" />
                                                                             </Grid>
                                                                             <!-- Size + Output path -->
                                                                             <Grid ColumnDefinitions="Auto,*" Margin="0,2,0,0">


### PR DESCRIPTION
## Overview

Adds start and end keyframe thumbnails to clip cards, making clip boundaries easier to identify visually.

## Changes

- Display start and end thumbnails for every clip
- Select and navigate to a clip by clicking its thumbnail or boundary time
- Use compact bracket notation for boundary timestamps
- Apply the compact boundary layout to export queue entries
- Support 8K, 1080p, 4:3, ultrawide, and portrait sources
- Preserve the original aspect ratio without cropping or stretching
- Remove unused time properties and localization resources

## Memory Management

- Store thumbnails at a fixed 160×90 resolution
- Never retain additional full-resolution frames
- Explicitly dispose thumbnails when replaced, removed, or closed
- Dispose partially created thumbnails when rendering fails
- Avoid duplicating thumbnail references in the export queue

## Tests

- Release test suite passed: 121/121
- Added aspect-fit coverage for multiple resolutions and aspect ratios

---

## 概述

为主界面的剪辑卡片增加入点和出点关键帧缩略图，帮助用户快速识别每个剪辑的边界画面。

## 主要改动

- 每个剪辑同时显示入点和出点缩略图
- 点击缩略图或边界时间，可选中对应剪辑并跳转到该关键帧
- 使用紧凑的中括号形式展示起止时间
- 同步优化导出队列中的边界时间布局
- 正确适配 8K、1080p、4:3、超宽屏和竖屏等画面比例
- 非 16:9 内容保持原始比例居中显示，不裁剪、不拉伸
- 删除不再使用的时间文本属性和本地化资源

## 内存管理

- 缩略图固定为 160×90，不保留完整分辨率帧
- 替换边界、删除剪辑及关闭文件时显式释放图片资源
- 绘制失败时释放已创建的缩略图
- 导出队列不复制或持有缩略图引用

## 测试

- Release 测试全部通过：121/121
- 增加多种分辨率和画面比例的等比适配测试