### PR TITLE
Add hardware decoding on Windows and macOS

### DIFF
--- a/src/TSCutter.GUI.Tests/AppConfigTests.cs
+++ b/src/TSCutter.GUI.Tests/AppConfigTests.cs
@@ -1,0 +1,38 @@
+using TSCutter.GUI.Models;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public class AppConfigTests
+{
+    [Fact]
+    public void PreferHardwareDecoding_DefaultsToCurrentPlatformCapability()
+    {
+        Assert.Equal(
+            AppConfig.IsHardwareDecodingSupported,
+            new AppConfig().PreferHardwareDecoding);
+    }
+
+    [Fact]
+    public void PreferHardwareDecoding_CannotBeEnabledOnUnsupportedPlatform()
+    {
+        var config = new AppConfig { PreferHardwareDecoding = true };
+
+        Assert.Equal(AppConfig.IsHardwareDecodingSupported, config.PreferHardwareDecoding);
+    }
+
+    [Theory]
+    [InlineData(true, true, true)]
+    [InlineData(false, true, false)]
+    [InlineData(true, false, false)]
+    [InlineData(false, false, false)]
+    public void NormalizeHardwareDecodingPreference_RequiresRequestAndPlatformSupport(
+        bool requested,
+        bool supported,
+        bool expected)
+    {
+        Assert.Equal(
+            expected,
+            AppConfig.NormalizeHardwareDecodingPreference(requested, supported));
+    }
+}

--- a/src/TSCutter.GUI.Tests/HardwareDecodeFallbackTests.cs
+++ b/src/TSCutter.GUI.Tests/HardwareDecodeFallbackTests.cs
@@ -1,0 +1,61 @@
+using TSCutter.GUI.Models;
+using Xunit;
+
+namespace TSCutter.GUI.Tests;
+
+public class HardwareDecodeFallbackTests
+{
+    [Fact]
+    public void ResolveHardwareFallbackSeekPts_ForwardNavigationDoesNotUseStaleSeekPosition()
+    {
+        var result = VideoInstance.ResolveHardwareFallbackSeekPts(
+            count: 1,
+            anchorPts: 90_000,
+            lastSeekPts: 0,
+            failurePts: null);
+
+        Assert.Equal(90_001, result);
+    }
+
+    [Fact]
+    public void ResolveHardwareFallbackSeekPts_PrefersFailedForwardFrame()
+    {
+        var result = VideoInstance.ResolveHardwareFallbackSeekPts(
+            count: 1,
+            anchorPts: 90_000,
+            lastSeekPts: 0,
+            failurePts: 180_000);
+
+        Assert.Equal(180_000, result);
+    }
+
+    [Theory]
+    [InlineData(89_999, true)]
+    [InlineData(90_000, false)]
+    [InlineData(90_001, false)]
+    public void IsDecodedFrameAtRequestedSide_BackwardRequiresEarlierFrame(long currentPts, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            VideoInstance.IsDecodedFrameAtRequestedSide(
+                backward: true,
+                requireForwardAfterAnchor: false,
+                currentPts: currentPts,
+                anchorPts: 90_000));
+    }
+
+    [Theory]
+    [InlineData(89_999, false)]
+    [InlineData(90_000, false)]
+    [InlineData(90_001, true)]
+    public void IsDecodedFrameAtRequestedSide_ForwardFallbackRequiresLaterFrame(long currentPts, bool expected)
+    {
+        Assert.Equal(
+            expected,
+            VideoInstance.IsDecodedFrameAtRequestedSide(
+                backward: false,
+                requireForwardAfterAnchor: true,
+                currentPts: currentPts,
+                anchorPts: 90_000));
+    }
+}

--- a/src/TSCutter.GUI/Extensions/FFmpegLibExtension.cs
+++ b/src/TSCutter.GUI/Extensions/FFmpegLibExtension.cs
@@ -1,13 +1,17 @@
+using System;
 using Sdcb.FFmpeg.Codecs;
 using Sdcb.FFmpeg.Common;
 using Sdcb.FFmpeg.Formats;
 using Sdcb.FFmpeg.Raw;
+using Sdcb.FFmpeg.Utils;
 using static Sdcb.FFmpeg.Raw.ffmpeg;
 
 namespace TSCutter.GUI.Extensions;
 
 public static unsafe class FFmpegLibExtension
 {
+    private const int AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX = 0x01;
+
     static int ThrowIfError(this int errorCode, string? message = null)
     {
         if (errorCode < 0)
@@ -41,5 +45,65 @@ public static unsafe class FFmpegLibExtension
     /// <see cref="avio_size"/>
     /// </summary>
     public static long GetFileSize(this FormatContext formatContext) => avio_size(formatContext.Pb!);
+
+    /// <summary>
+    /// 判断解码器是否支持通过指定硬件设备上下文输出硬件帧。
+    /// </summary>
+    public static bool SupportsHardwareDevice(this Codec codec, AVHWDeviceType deviceType)
+    {
+        AVCodec* rawCodec = codec;
+        for (var index = 0; ; index++)
+        {
+            var config = avcodec_get_hw_config(rawCodec, index);
+            if (config == null)
+                return false;
+
+            if (config->device_type == deviceType &&
+                (config->methods & AV_CODEC_HW_CONFIG_METHOD_HW_DEVICE_CTX) != 0)
+            {
+                return true;
+            }
+        }
+    }
+
+    /// <summary>
+    /// 创建硬件设备并将其所有权交给解码器上下文。
+    /// </summary>
+    public static void AttachHardwareDevice(this CodecContext codecContext, AVHWDeviceType deviceType)
+    {
+        AVBufferRef* deviceContext = null;
+        av_hwdevice_ctx_create(ref deviceContext, deviceType, null, null, 0)
+            .ThrowIfError($"Failed to create {deviceType} hardware device.");
+
+        if (deviceContext == null)
+            throw new InvalidOperationException($"Failed to create {deviceType} hardware device.");
+
+        // hw_device_ctx 设置后由 AVCodecContext 持有并在释放解码器时解除引用。
+        AVCodecContext* rawCodecContext = codecContext;
+        rawCodecContext->hw_device_ctx = deviceContext;
+    }
+
+    /// <summary>
+    /// 将 GPU 中的硬件帧复制到 CPU 内存，供现有的 swscale 绘制链路使用。
+    /// </summary>
+    public static Frame TransferToSoftwareFrame(this Frame hardwareFrame)
+    {
+        var softwareFrame = new Frame();
+        try
+        {
+            AVFrame* source = hardwareFrame;
+            AVFrame* destination = softwareFrame;
+            av_hwframe_transfer_data(destination, source, 0)
+                .ThrowIfError("Failed to transfer hardware frame to system memory.");
+            av_frame_copy_props(destination, source)
+                .ThrowIfError("Failed to copy hardware frame properties.");
+            return softwareFrame;
+        }
+        catch
+        {
+            softwareFrame.Dispose();
+            throw;
+        }
+    }
 
 }

--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -97,6 +97,10 @@
     <x:String x:Key="String.Settings.CurrentLightTheme">Light theme</x:String>
     <x:String x:Key="String.Settings.CurrentDarkTheme">Dark theme</x:String>
     <x:String x:Key="String.Settings.AutoCheckForUpdates">Auto check for updates after app started</x:String>
+    <x:String x:Key="String.Settings.PreferHardwareDecoding">Prefer hardware decoding</x:String>
+    <x:String x:Key="String.Settings.PreferHardwareDecodingTip">Available on Windows and macOS. Unsupported codecs automatically use software decoding.</x:String>
+    <x:String x:Key="String.Status.HardwareDecoding">HW</x:String>
+    <x:String x:Key="String.Status.SoftwareDecoding">SW</x:String>
     <x:String x:Key="String.Settings.Theme.ThemeVariantMode">Theme mode</x:String>
     <x:String x:Key="String.Settings.Theme.AutoDetect">Auto detect</x:String>
     <x:String x:Key="String.Settings.Theme.Light">Light</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -97,6 +97,10 @@
     <x:String x:Key="String.Settings.CurrentLightTheme">当前浅色主题</x:String>
     <x:String x:Key="String.Settings.CurrentDarkTheme">当前深色主题</x:String>
     <x:String x:Key="String.Settings.AutoCheckForUpdates">程序启动后自动检查更新</x:String>
+    <x:String x:Key="String.Settings.PreferHardwareDecoding">优先使用硬件解码</x:String>
+    <x:String x:Key="String.Settings.PreferHardwareDecodingTip">仅支持 Windows 和 macOS；不支持的编码会自动使用软件解码。</x:String>
+    <x:String x:Key="String.Status.HardwareDecoding">HW</x:String>
+    <x:String x:Key="String.Status.SoftwareDecoding">SW</x:String>
     <x:String x:Key="String.Settings.Theme.ThemeVariantMode">主题模式</x:String>
     <x:String x:Key="String.Settings.Theme.AutoDetect">自动检测</x:String>
     <x:String x:Key="String.Settings.Theme.Light">浅色</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -97,6 +97,10 @@
     <x:String x:Key="String.Settings.CurrentLightTheme">目前淺色佈景主題</x:String>
     <x:String x:Key="String.Settings.CurrentDarkTheme">目前深色佈景主題</x:String>
     <x:String x:Key="String.Settings.AutoCheckForUpdates">程式啟動後自動檢查更新</x:String>
+    <x:String x:Key="String.Settings.PreferHardwareDecoding">優先使用硬體解碼</x:String>
+    <x:String x:Key="String.Settings.PreferHardwareDecodingTip">僅支援 Windows 和 macOS；不支援的編碼會自動使用軟體解碼。</x:String>
+    <x:String x:Key="String.Status.HardwareDecoding">HW</x:String>
+    <x:String x:Key="String.Status.SoftwareDecoding">SW</x:String>
     <x:String x:Key="String.Settings.Theme.ThemeVariantMode">佈景主題模式</x:String>
     <x:String x:Key="String.Settings.Theme.AutoDetect">自動偵測</x:String>
     <x:String x:Key="String.Settings.Theme.Light">淺色</x:String>

--- a/src/TSCutter.GUI/Models/AppConfig.cs
+++ b/src/TSCutter.GUI/Models/AppConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text.Json.Serialization;
 
@@ -5,6 +6,8 @@ namespace TSCutter.GUI.Models;
 
 public class AppConfig
 {
+    private bool _preferHardwareDecoding = IsHardwareDecodingSupported;
+
     // 系统当前是否处于深色模式
     [JsonIgnore]
     public static bool IsSystemDarkMode { get; set; }
@@ -19,5 +22,17 @@ public class AppConfig
     public ThemeVariantMode ThemeVariantMode { get; set; } = ThemeVariantMode.Automatic;
     public bool AutoDetectLanguage { get; set; } = true;
     public bool AutoCheckForUpdates { get; set; } = true;
+    public bool PreferHardwareDecoding
+    {
+        get => IsHardwareDecodingSupported && _preferHardwareDecoding;
+        set => _preferHardwareDecoding = NormalizeHardwareDecodingPreference(
+            value,
+            IsHardwareDecodingSupported);
+    }
     public string? FFmpegRootPath { get; set; }
+
+    [JsonIgnore]
+    public static bool IsHardwareDecodingSupported => OperatingSystem.IsWindows() || OperatingSystem.IsMacOS();
+
+    internal static bool NormalizeHardwareDecodingPreference(bool requested, bool supported) => requested && supported;
 }

--- a/src/TSCutter.GUI/Models/VideoInstance.cs
+++ b/src/TSCutter.GUI/Models/VideoInstance.cs
@@ -13,7 +13,7 @@ using static TSCutter.GUI.Utils.CommonUtil;
 
 namespace TSCutter.GUI.Models;
 
-public class VideoInstance(string filePath) : IDisposable
+public class VideoInstance(string filePath, bool enableHardwareDecoding = false) : IDisposable
 {
     private static readonly HashSet<string> HardwareTags = new() 
     { 
@@ -22,13 +22,23 @@ public class VideoInstance(string filePath) : IDisposable
 
     private const int MAX_FAILURE_COUT = 100;
     private const int AV_PKT_FLAG_KEY_FRAME = 0x0001;
+    private static readonly AVHWDeviceType[] MacHardwareDevices = [AVHWDeviceType.Videotoolbox];
+    private static readonly AVHWDeviceType[] WindowsHardwareDevices =
+        [AVHWDeviceType.D3d11va, AVHWDeviceType.Dxva2];
+    private static readonly AVHWDeviceType[] NoHardwareDevices = [];
+
     public long PositionInFile { get; private set; } = 0;
     public long CurrentPts => currentKeyFramePts;
     public double EstimatedKeyFrameIntervalSeconds => keyFrameGap > 0 && timeBase.Den != 0
         ? keyFrameGap * timeBase.Num / (double)timeBase.Den
         : 0;
     public bool Inited { get; private set; } = false;
+    public bool IsHardwareDecoding { get; private set; }
+    private string hardwareDecoderName = string.Empty;
     private bool AudioMode { get; set; } = false;
+    private bool hardwareDecoderOpened;
+    private readonly bool preferHardwareDecoding = enableHardwareDecoding && AppConfig.IsHardwareDecodingSupported;
+    private List<Codec> softwareDecoders = [];
     
     private FormatContext inFc;
     private CodecContext videoDecoder;
@@ -44,7 +54,7 @@ public class VideoInstance(string filePath) : IDisposable
     private double timelineDurationSeconds;
     private long timelineDurationPts;
     
-    private string videoPath = filePath;
+    private readonly string videoPath = filePath;
 
     public async Task InitVideoAsync()
     {
@@ -64,7 +74,7 @@ public class VideoInstance(string filePath) : IDisposable
             throw new Exception("Read Failed!");
         }
 
-        var decoders = Codec.FindDecoders(inVideoStream.Codecpar!.CodecId)
+        softwareDecoders = Codec.FindDecoders(inVideoStream.Codecpar!.CodecId)
             .Where(x =>
             {
                 var name = x.Name;
@@ -72,12 +82,12 @@ public class VideoInstance(string filePath) : IDisposable
                 return HardwareTags.All(tag => !name.Contains(tag, StringComparison.OrdinalIgnoreCase));
             })
             .ToList();
-        if (decoders.Count == 0)
+        if (softwareDecoders.Count == 0)
         {
             throw new Exception("Cant find decoder!");
         }
 
-        foreach (var decoder in decoders)
+        foreach (var decoder in softwareDecoders)
         {
             Console.WriteLine($"Found decoder: {decoder.Name}");
         }
@@ -86,11 +96,12 @@ public class VideoInstance(string filePath) : IDisposable
         timeBase = inVideoStream.TimeBase;
         UpdateTimelineDuration();
 
-        var firstDecoder = decoders.Last();
-        videoDecoder = new(firstDecoder);
-        videoDecoder.SkipFrame = AVDiscard.Nonkey;
-        videoDecoder.FillParameters(inVideoStream.Codecpar!);
-        videoDecoder.Open();
+        var decoderOpened = preferHardwareDecoding && TryOpenHardwareDecoder();
+        if (!decoderOpened)
+            decoderOpened = TryOpenSoftwareDecoder();
+
+        if (!decoderOpened)
+            throw new Exception("Cant open decoder!");
 
         try
         {
@@ -112,6 +123,106 @@ public class VideoInstance(string filePath) : IDisposable
         Inited = true;
     }
 
+    private bool TryOpenHardwareDecoder()
+    {
+        foreach (var deviceType in GetHardwareDeviceCandidates())
+        {
+            foreach (var decoder in softwareDecoders.AsEnumerable().Reverse())
+            {
+                if (!decoder.SupportsHardwareDevice(deviceType))
+                    continue;
+
+                CodecContext? candidate = null;
+                try
+                {
+                    candidate = new CodecContext(decoder);
+                    candidate.FillParameters(inVideoStream.Codecpar!);
+                    candidate.SkipFrame = AVDiscard.Nonkey;
+                    candidate.AttachHardwareDevice(deviceType);
+                    candidate.Open();
+                    ReplaceVideoDecoder(candidate);
+                    candidate = null;
+
+                    hardwareDecoderOpened = true;
+                    IsHardwareDecoding = true;
+                    hardwareDecoderName = GetHardwareDeviceDisplayName(deviceType);
+                    Console.WriteLine($"Hardware decoder opened: {decoder.Name} ({hardwareDecoderName})");
+                    return true;
+                }
+                catch (Exception exception)
+                {
+                    Console.WriteLine($"Failed to open {decoder.Name} with {deviceType}: {exception.Message}");
+                }
+                finally
+                {
+                    candidate?.Close();
+                    candidate?.Dispose();
+                }
+            }
+        }
+
+        Console.WriteLine("No supported hardware decoder was available; falling back to software decoding.");
+        return false;
+    }
+
+    private bool TryOpenSoftwareDecoder()
+    {
+        foreach (var decoder in softwareDecoders.AsEnumerable().Reverse())
+        {
+            CodecContext? candidate = null;
+            try
+            {
+                candidate = new CodecContext(decoder);
+                candidate.FillParameters(inVideoStream.Codecpar!);
+                candidate.SkipFrame = AVDiscard.Nonkey;
+                candidate.Open();
+                ReplaceVideoDecoder(candidate);
+                candidate = null;
+
+                hardwareDecoderOpened = false;
+                IsHardwareDecoding = false;
+                hardwareDecoderName = string.Empty;
+                Console.WriteLine($"Software decoder opened: {decoder.Name}");
+                return true;
+            }
+            catch (Exception exception)
+            {
+                Console.WriteLine($"Failed to open software decoder {decoder.Name}: {exception.Message}");
+            }
+            finally
+            {
+                candidate?.Close();
+                candidate?.Dispose();
+            }
+        }
+
+        return false;
+    }
+
+    private void ReplaceVideoDecoder(CodecContext decoder)
+    {
+        videoDecoder?.Close();
+        videoDecoder?.Dispose();
+        videoDecoder = decoder;
+    }
+
+    private static IReadOnlyList<AVHWDeviceType> GetHardwareDeviceCandidates()
+    {
+        if (OperatingSystem.IsMacOS())
+            return MacHardwareDevices;
+        if (OperatingSystem.IsWindows())
+            return WindowsHardwareDevices;
+        return NoHardwareDevices;
+    }
+
+    private static string GetHardwareDeviceDisplayName(AVHWDeviceType deviceType) => deviceType switch
+    {
+        AVHWDeviceType.Videotoolbox => "VideoToolbox",
+        AVHWDeviceType.D3d11va => "D3D11VA",
+        AVHWDeviceType.Dxva2 => "DXVA2",
+        _ => deviceType.ToString()
+    };
+
     private void InitAudio(FormatContext inFc)
     {
         inVideoStream = inFc.GetAudioStream();
@@ -131,12 +242,16 @@ public class VideoInstance(string filePath) : IDisposable
         UpdateTimelineDuration();
 
         var firstDecoder = decoders.First();
-        videoDecoder = new(Codec.FindDecoderById(firstDecoder.Id));
-        videoDecoder.FillParameters(inVideoStream.Codecpar!);
-        videoDecoder.Open();
+        var audioDecoder = new CodecContext(Codec.FindDecoderById(firstDecoder.Id));
+        audioDecoder.FillParameters(inVideoStream.Codecpar!);
+        audioDecoder.Open();
+        ReplaceVideoDecoder(audioDecoder);
 
         keyFrameGap = 90000;
         AudioMode = true;
+        hardwareDecoderOpened = false;
+        IsHardwareDecoding = false;
+        hardwareDecoderName = string.Empty;
     }
     
     public async Task SeekToTimeAsync(TimeSpan timeSpan)
@@ -185,16 +300,45 @@ public class VideoInstance(string filePath) : IDisposable
 
     private DecodeResult DecodeNextFrame(int count = 1)
     {
-        return DecodeNextFrame(count, currentKeyFramePts, true, 0);
+        var anchorPts = currentKeyFramePts;
+        try
+        {
+            return DecodeNextFrame(count, anchorPts, true, 0);
+        }
+        catch (HardwareDecodeException exception)
+        {
+            Console.WriteLine($"Hardware decoding failed, switching to software: {exception.InnerException?.Message ?? exception.Message}");
+            if (!TryOpenSoftwareDecoder())
+                throw;
+
+            // 普通“下一帧”不会更新 lastSeekPts，回退时必须结合失败帧和当前锚点计算恢复位置。
+            var fallbackSeekPts = ResolveHardwareFallbackSeekPts(
+                count,
+                anchorPts,
+                lastSeekPts,
+                exception.RetryPts);
+            Seek(fallbackSeekPts, count < 0 ? AVSEEK_FLAG.Backward : 0);
+            return DecodeNextFrame(
+                count,
+                anchorPts,
+                applyInitialSeek: false,
+                retryCount: 0,
+                requireForwardAfterAnchor: count >= 0);
+        }
     }
 
-    private DecodeResult DecodeNextFrame(int count, long anchorPts, bool applyInitialSeek, int retryCount)
+    private DecodeResult DecodeNextFrame(
+        int count,
+        long anchorPts,
+        bool applyInitialSeek,
+        int retryCount,
+        bool requireForwardAfterAnchor = false)
     {
         var failureCount = 0;
         var backward = count < 0;
 
         if (retryCount > MAX_FAILURE_COUT)
-            throw new TooManyDecodeFailuresException("Too many failed packets!");
+            ThrowDecodeFailure();
         
         if (applyInitialSeek && count < 0)
         {
@@ -229,17 +373,24 @@ public class VideoInstance(string filePath) : IDisposable
             var result = DecodePacket(packet, packet.Position);
             if (result != null)
             {
-                if (!backward || currentKeyFramePts < anchorPts)
+                if (IsDecodedFrameAtRequestedSide(
+                        backward,
+                        requireForwardAfterAnchor,
+                        currentKeyFramePts,
+                        anchorPts))
                 {
                     return result;
                 }
 
                 Console.WriteLine($"Skip[SameOrLaterFrame] keyFrame: {currentKeyFramePts}, anchorPts: {anchorPts}");
-                break;
+                result.Bitmap.Dispose();
+                if (backward)
+                    break;
+                continue;
             }
             if (failureCount++ > MAX_FAILURE_COUT)
             {
-                throw new TooManyDecodeFailuresException("Too many failed packets!");
+                ThrowDecodeFailure();
             }
             Console.WriteLine("result is null");
         }
@@ -250,7 +401,44 @@ public class VideoInstance(string filePath) : IDisposable
 
         var retryStep = backward ? keyFrameGap : keyFrameGap / 2;
         Seek(lastSeekPts - retryStep, backward ? AVSEEK_FLAG.Backward : 0);
-        return DecodeNextFrame(backward ? -1 : 1, anchorPts, false, retryCount + 1);
+        return DecodeNextFrame(
+            backward ? -1 : 1,
+            anchorPts,
+            applyInitialSeek: false,
+            retryCount: retryCount + 1,
+            requireForwardAfterAnchor: requireForwardAfterAnchor);
+    }
+
+    internal static long ResolveHardwareFallbackSeekPts(
+        int count,
+        long anchorPts,
+        long lastSeekPts,
+        long? failurePts)
+    {
+        if (count < 0)
+            return failurePts ?? lastSeekPts;
+
+        var firstPtsAfterAnchor = anchorPts == long.MaxValue ? long.MaxValue : anchorPts + 1;
+        return Math.Max(firstPtsAfterAnchor, failurePts ?? lastSeekPts);
+    }
+
+    internal static bool IsDecodedFrameAtRequestedSide(
+        bool backward,
+        bool requireForwardAfterAnchor,
+        long currentPts,
+        long anchorPts)
+    {
+        return backward
+            ? currentPts < anchorPts
+            : !requireForwardAfterAnchor || currentPts > anchorPts;
+    }
+
+    private void ThrowDecodeFailure()
+    {
+        var exception = new TooManyDecodeFailuresException("Too many failed packets!");
+        if (hardwareDecoderOpened)
+            throw new HardwareDecodeException(exception);
+        throw exception;
     }
 
     public double GetVideoDurationInSeconds()
@@ -387,24 +575,61 @@ public class VideoInstance(string filePath) : IDisposable
                     continue;
 #pragma warning restore CS0618 // Obsolete
 
-                // 音频模式无法解码 返回固定图片
-                var bitmap = AudioMode ? ImageUtil.BlankImage : ImageUtil.CreateBitmapFromFrame(frame);
-                return new DecodeResult()
+                // 硬件帧位于 GPU 内存，先回读到系统内存，再复用原有的位图转换逻辑。
+                Frame? softwareFrame = null;
+                try
                 {
-                    Bitmap = bitmap,
-                    FrameTimestamp = PtsToTimeSpan(pts),
-                };
+                    if (!AudioMode && frame.HwFramesContext != null)
+                        softwareFrame = frame.TransferToSoftwareFrame();
+                }
+                catch (Exception exception)
+                {
+                    // 硬件帧无法回读通常表示设备链路失效，此时才立即切换软件解码器。
+                    throw new HardwareDecodeException(exception, pts);
+                }
+                using (softwareFrame)
+                {
+                    IsHardwareDecoding = softwareFrame != null;
+                    Avalonia.Media.Imaging.Bitmap bitmap;
+                    try
+                    {
+                        bitmap = AudioMode
+                            ? ImageUtil.BlankImage
+                            : ImageUtil.CreateBitmapFromFrame(softwareFrame ?? frame);
+                    }
+                    catch (Exception exception)
+                    {
+                        // 位图绘制属于界面链路，失败时不能据此判定硬件解码器不可用。
+                        Console.WriteLine(exception);
+                        return null;
+                    }
+                    return new DecodeResult()
+                    {
+                        Bitmap = bitmap,
+                        FrameTimestamp = PtsToTimeSpan(pts),
+                    };
+                }
             }
+        }
+        catch (HardwareDecodeException)
+        {
+            throw;
         }
         catch (Exception e)
         {
             Console.WriteLine(e);
-            // Return null to indicate failure and continue with the next packet
+            // 局部码流错误在硬解和软解下都可能出现，继续尝试后续关键帧。
             return null;
         }
         
         // If no frames were successfully processed
         Console.WriteLine("no frames were successfully processed");
         return null;
+    }
+
+    private sealed class HardwareDecodeException(Exception innerException, long? retryPts = null)
+        : Exception("Hardware decoding failed.", innerException)
+    {
+        public long? RetryPts { get; } = retryPts;
     }
 }

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -760,12 +760,22 @@ public partial class MainWindowViewModel : ViewModelBase
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(StatusInfoText))]
     public partial long DecodeCost { get; set; } = 0L;
-    
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(StatusInfoText))]
+    public partial bool IsHardwareDecoding { get; set; }
+
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsDecoding))]
     public partial int DecodingOpCount { get; set; } = 0;
 
-    public string StatusInfoText => IsVideoInitialized ? $"{VideoInfoText} | {DecodeCost,3}ms" : PleaseLoadTip;
+    private string DecodeModeText => IsHardwareDecoding
+        ? LocalizationManager.Instance.String_Status_HardwareDecoding
+        : LocalizationManager.Instance.String_Status_SoftwareDecoding;
+
+    public string StatusInfoText => IsVideoInitialized
+        ? $"{VideoInfoText} | {DecodeModeText} | {DecodeCost,3}ms"
+        : PleaseLoadTip;
     public bool IsDecoding => DecodingOpCount > 0;
 
     public string ZoomFactorStr => string.Format(LocalizationManager.Instance.String_ZoomFactor, $"{ZoomFactor * 100.0:0}");
@@ -901,6 +911,11 @@ public partial class MainWindowViewModel : ViewModelBase
             Console.WriteLine(e);
             await ShowMessageAsync(e.Message, LocalizationManager.Instance.String_FailedToDecode, MessageBoxIcon.Error);
         }
+        finally
+        {
+            // 即使软件回退后的重试仍失败，状态栏也必须反映解码器的实际模式。
+            UpdateDecodeMode();
+        }
     }
 
     private void ClearVars()
@@ -916,6 +931,7 @@ public partial class MainWindowViewModel : ViewModelBase
         CurrentTime = 0.0;
         TimelineViewport.Reset(0, 0);
         DecodeCost = 0L;
+        IsHardwareDecoding = false;
     }
 
     private async Task LoadVideoAsync()
@@ -926,8 +942,11 @@ public partial class MainWindowViewModel : ViewModelBase
             _videoInstance?.Close();
             await RunDecodeOperationAsync(async () =>
             {
-                _videoInstance = new VideoInstance(VideoPath);
+                _videoInstance = new VideoInstance(
+                    VideoPath,
+                    _configService.CurrentConfig.PreferHardwareDecoding);
                 await _videoInstance.InitVideoAsync();
+                UpdateDecodeMode();
                 VideoInfoText = _videoInstance.GetVideoInfoText();
                 DurationMax = _videoInstance.GetVideoDurationInSeconds();
                 TimelineViewport.Reset(
@@ -1034,6 +1053,14 @@ public partial class MainWindowViewModel : ViewModelBase
         _videoInstance?.Dispose();
         _videoInstance = null;
         VideoPath = string.Empty;
+    }
+
+    private void UpdateDecodeMode()
+    {
+        if (_videoInstance is null)
+            return;
+
+        IsHardwareDecoding = _videoInstance.IsHardwareDecoding;
     }
 
     private void DisposeClipThumbnails()

--- a/src/TSCutter.GUI/ViewModels/SettingsWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/SettingsWindowViewModel.cs
@@ -22,6 +22,8 @@ public partial class SettingsWindowViewModel : ViewModelBase, IModalDialogViewMo
     [ObservableProperty]
     private bool _autoCheckForUpdates;
     [ObservableProperty]
+    private bool _preferHardwareDecoding;
+    [ObservableProperty]
     private ThemeModel _selectedTheme;
     [ObservableProperty]
     private ThemeModel _selectedDarkTheme;
@@ -31,6 +33,7 @@ public partial class SettingsWindowViewModel : ViewModelBase, IModalDialogViewMo
     private ThemeVariantMode _selectedThemeVariantMode;
 
     public bool IsLanguageEnable => !AutoDetectLanguage;
+    public bool IsHardwareDecodingAvailable => AppConfig.IsHardwareDecodingSupported;
     public List<ThemeModel> Themes => ThemeModel.AllThemes;
     public List<ThemeModel> DarkThemes => ThemeModel.AllDarkThemes;
     public List<SupportedLang> Languages => _locService.SupportedLanguages;
@@ -41,6 +44,7 @@ public partial class SettingsWindowViewModel : ViewModelBase, IModalDialogViewMo
         _locService = localizationService;
         AutoDetectLanguage = _configService.CurrentConfig.AutoDetectLanguage;
         AutoCheckForUpdates = _configService.CurrentConfig.AutoCheckForUpdates;
+        PreferHardwareDecoding = _configService.CurrentConfig.PreferHardwareDecoding;
         SelectedTheme = _configService.CurrentConfig.ThemeModel;
         SelectedDarkTheme = _configService.CurrentConfig.DarkThemeModel;
         SelectedThemeVariantMode = _configService.CurrentConfig.ThemeVariantMode;
@@ -76,6 +80,7 @@ public partial class SettingsWindowViewModel : ViewModelBase, IModalDialogViewMo
         // 更新配置
         _configService.CurrentConfig.AutoDetectLanguage = AutoDetectLanguage;
         _configService.CurrentConfig.AutoCheckForUpdates = AutoCheckForUpdates;
+        _configService.CurrentConfig.PreferHardwareDecoding = PreferHardwareDecoding;
         _configService.CurrentConfig.ThemeVariantMode = SelectedThemeVariantMode;
 
         // 应用主题

--- a/src/TSCutter.GUI/Views/SettingsWindow.axaml
+++ b/src/TSCutter.GUI/Views/SettingsWindow.axaml
@@ -120,6 +120,10 @@
                     </HeaderedContentControl>
                     <CheckBox IsChecked="{Binding AutoCheckForUpdates}"
                               Content="{DynamicResource String.Settings.AutoCheckForUpdates}" />
+                    <CheckBox IsChecked="{Binding PreferHardwareDecoding}"
+                              IsEnabled="{Binding IsHardwareDecodingAvailable}"
+                              Content="{DynamicResource String.Settings.PreferHardwareDecoding}"
+                              ToolTip.Tip="{DynamicResource String.Settings.PreferHardwareDecodingTip}" />
                 </StackPanel>
             </TabItem>
         </TabControl>


### PR DESCRIPTION
## Overview

Adds optional hardware-accelerated video decoding on Windows and macOS while preserving automatic software fallback for unsupported codecs and streams.

## Changes

- Enable VideoToolbox hardware decoding on macOS
- Prefer D3D11VA and fall back to DXVA2 on Windows
- Enable hardware decoding by default on supported platforms
- Disable and force off the setting on Linux
- Add a localized hardware decoding option to Settings
- Display the actual decode mode as `HW` or `SW` in the status bar
- Reuse the decoder and hardware device context throughout the opened file
- Transfer hardware frames to system memory for the existing preview pipeline
- Continue past isolated bitstream errors without prematurely abandoning hardware decoding
- Fall back to software decoding when hardware frame transfer or sustained decoding fails
- Preserve the current timeline position when switching decoders
- Release temporary frames and skipped preview bitmaps explicitly

## Compatibility

Hardware decoding is selected according to the capabilities reported by FFmpeg and the current platform. Unsupported codecs, profiles, interlacing modes, or device configurations automatically use software decoding.

## Tests

- Release test suite passed: 135/135
- Verified VideoToolbox decoding with H.264 hardware frames on macOS
- Verified software fallback for unsupported H.264 stream configurations
- macOS Release build passed
- Windows `win-x64` Release build passed

---

## 概述

在 Windows 和 macOS 上增加可选的硬件加速视频解码，并为不受支持的编码和码流保留自动软件回退能力。

## 主要改动

- macOS 使用 VideoToolbox 硬件解码
- Windows 优先使用 D3D11VA，并可回退到 DXVA2
- 在支持的平台上默认启用硬件解码
- Linux 下强制关闭并禁用对应设置
- 在设置窗口增加完整的多语言硬件解码选项
- 状态栏使用 `HW` 或 `SW` 显示实际解码模式
- 打开文件期间复用解码器和硬件设备上下文
- 将硬件帧回读到系统内存并复用现有预览链路
- 局部码流错误不会立即导致硬解回退
- 硬件帧传输失败或持续无法解码时自动切换软件解码
- 切换解码器时保持当前时间轴位置
- 显式释放临时帧和被跳过的预览位图

## 兼容性

硬件解码会根据 FFmpeg 报告的平台和解码器能力启用。不受支持的编码、Profile、隔行模式或设备配置会自动使用软件解码。

## 测试

- Release 测试全部通过：135/135
- 已在 macOS 验证 H.264 VideoToolbox 硬件帧解码
- 已验证不受支持的 H.264 码流配置能够回退软件解码
- macOS Release 构建通过
- Windows `win-x64` Release 构建通过