### PR TITLE
Improve clip selection and separate export actions

### DIFF
--- a/src/TSCutter.GUI/Lang/en-US.axaml
+++ b/src/TSCutter.GUI/Lang/en-US.axaml
@@ -63,9 +63,11 @@
     <x:String x:Key="String.Navigate.Next20">Next 20</x:String>
     <x:String x:Key="String.SaveClipTip">Save Current Clip</x:String>
     <x:String x:Key="String.SaveClip">Save Clip</x:String>
-    <x:String x:Key="String.ExportAll">Export All</x:String>
-    <x:String x:Key="String.ExportAllTip">Export all clips to the source directory</x:String>
-    <x:String x:Key="String.ExportAllConfirm">Export {0} clips to the source directory?&#10;&#10;Output: {1}</x:String>
+    <x:String x:Key="String.ExportAll">Export Separately</x:String>
+    <x:String x:Key="String.ExportAllTip">Export every clip as a separate file to the source directory</x:String>
+    <x:String x:Key="String.ExportAllConfirm">Export {0} clips as separate files to the source directory?&#10;&#10;Output: {1}</x:String>
+    <x:String x:Key="String.Clips.SelectAll">Select All</x:String>
+    <x:String x:Key="String.Clips.SelectAllTip">Select all clips</x:String>
     <x:String x:Key="String.Clips.Done">Done</x:String>
     <x:String x:Key="String.Clips.Failed">Failed</x:String>
     <x:String x:Key="String.Clips.Cancelled">Cancelled</x:String>

--- a/src/TSCutter.GUI/Lang/zh-CN.axaml
+++ b/src/TSCutter.GUI/Lang/zh-CN.axaml
@@ -63,9 +63,11 @@
     <x:String x:Key="String.Navigate.Next20">后 20</x:String>
     <x:String x:Key="String.SaveClipTip">保存当前片段</x:String>
     <x:String x:Key="String.SaveClip">保存片段</x:String>
-    <x:String x:Key="String.ExportAll">全部导出</x:String>
-    <x:String x:Key="String.ExportAllTip">将所有片段导出到源文件所在目录</x:String>
-    <x:String x:Key="String.ExportAllConfirm">将 {0} 个片段导出到源文件所在目录？&#10;&#10;输出目录：{1}</x:String>
+    <x:String x:Key="String.ExportAll">分别导出</x:String>
+    <x:String x:Key="String.ExportAllTip">将全部剪辑分别导出为独立文件，并保存到源文件所在目录</x:String>
+    <x:String x:Key="String.ExportAllConfirm">将 {0} 个剪辑分别导出为独立文件？&#10;&#10;输出目录：{1}</x:String>
+    <x:String x:Key="String.Clips.SelectAll">全选</x:String>
+    <x:String x:Key="String.Clips.SelectAllTip">选择全部剪辑</x:String>
     <x:String x:Key="String.Clips.Done">完成</x:String>
     <x:String x:Key="String.Clips.Failed">失败</x:String>
     <x:String x:Key="String.Clips.Cancelled">已取消</x:String>

--- a/src/TSCutter.GUI/Lang/zh-TW.axaml
+++ b/src/TSCutter.GUI/Lang/zh-TW.axaml
@@ -63,9 +63,11 @@
     <x:String x:Key="String.Navigate.Next20">後 20</x:String>
     <x:String x:Key="String.SaveClipTip">儲存目前片段</x:String>
     <x:String x:Key="String.SaveClip">儲存片段</x:String>
-    <x:String x:Key="String.ExportAll">全部匯出</x:String>
-    <x:String x:Key="String.ExportAllTip">將所有片段匯出到來源檔案所在目錄</x:String>
-    <x:String x:Key="String.ExportAllConfirm">將 {0} 個片段匯出到來源檔案所在目錄？&#10;&#10;輸出目錄：{1}</x:String>
+    <x:String x:Key="String.ExportAll">分別匯出</x:String>
+    <x:String x:Key="String.ExportAllTip">將全部剪輯分別匯出為獨立檔案，並儲存到來源檔案所在目錄</x:String>
+    <x:String x:Key="String.ExportAllConfirm">將 {0} 個剪輯分別匯出為獨立檔案？&#10;&#10;輸出目錄：{1}</x:String>
+    <x:String x:Key="String.Clips.SelectAll">全選</x:String>
+    <x:String x:Key="String.Clips.SelectAllTip">選取全部剪輯</x:String>
     <x:String x:Key="String.Clips.Done">完成</x:String>
     <x:String x:Key="String.Clips.Failed">失敗</x:String>
     <x:String x:Key="String.Clips.Cancelled">已取消</x:String>

--- a/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
+++ b/src/TSCutter.GUI/ViewModels/MainWindowViewModel.cs
@@ -197,8 +197,22 @@ public partial class MainWindowViewModel : ViewModelBase
         OnPropertyChanged(nameof(SelectedClipRanges));
         OnPropertyChanged(nameof(SelectedClipEstimatedSizeStr));
         OnPropertyChanged(nameof(SelectedClipsSummaryStr));
+        SelectAllClipsCommand.NotifyCanExecuteChanged();
         MergeSelectedClipsCommand.NotifyCanExecuteChanged();
     }
+
+    [RelayCommand(CanExecute = nameof(CanSelectAllClips))]
+    private void SelectAllClips()
+    {
+        foreach (var clip in Clips)
+            clip.IsSelected = true;
+
+        SelectedClip ??= Clips.FirstOrDefault();
+        _clipSelectionAnchor = SelectedClip;
+        NotifyClipSelectionChanged();
+    }
+
+    private bool CanSelectAllClips => Clips.Any(clip => !clip.IsSelected);
 
     private (int Count, long Bytes, double DurationSeconds) GetSelectedClipAggregate()
     {

--- a/src/TSCutter.GUI/Views/MainWindow.axaml
+++ b/src/TSCutter.GUI/Views/MainWindow.axaml
@@ -274,13 +274,22 @@
                                                 </TextBlock>
                                             </TabItem.Header>
                                             <DockPanel>
-                                                <Button DockPanel.Dock="Bottom"
-                                                        Command="{Binding ExportAllCommand}"
-                                                        HorizontalAlignment="Stretch"
-                                                        ToolTip.Tip="{DynamicResource String.ExportAllTip}"
-                                                        Margin="0,2,0,0">
-                                                    <TextBlock Text="{DynamicResource String.ExportAll}" />
-                                                </Button>
+                                                <Grid DockPanel.Dock="Bottom"
+                                                      ColumnDefinitions="*,*"
+                                                      ColumnSpacing="4"
+                                                      Margin="0,2,0,0">
+                                                    <Button Grid.Column="0"
+                                                            Command="{Binding SelectAllClipsCommand}"
+                                                            ToolTip.Tip="{DynamicResource String.Clips.SelectAllTip}">
+                                                        <TextBlock Text="{DynamicResource String.Clips.SelectAll}" />
+                                                    </Button>
+                                                    <Button Grid.Column="1"
+                                                            Command="{Binding ExportAllCommand}"
+                                                            HorizontalAlignment="Stretch"
+                                                            ToolTip.Tip="{DynamicResource String.ExportAllTip}">
+                                                        <TextBlock Text="{DynamicResource String.ExportAll}" />
+                                                    </Button>
+                                                </Grid>
                                                 <Grid>
                                                     <!-- Empty state -->
                                                     <TextBlock Text="{DynamicResource String.Clips.Empty}"


### PR DESCRIPTION
- Add a Select All action to the clip list.
- Give the Select All and export buttons equal width.
- Rename Export All to Export Separately and clarify that each clip is written as an independent file.
- Update English, Simplified Chinese, and Traditional Chinese resources.

Testing:
- Release build completed successfully.
- All 135 tests passed.

---

- 在剪辑列表中增加“全选”操作。
- “全选”和导出按钮平分可用宽度。
- 将“全部导出”改为“分别导出”，并明确每个剪辑会输出为独立文件。
- 同步更新英文、简体中文和繁体中文资源。

测试：
- Release 构建成功。
- 135 项测试全部通过。